### PR TITLE
perf: prefetch nav links + fix Android UI freeze + sign out fix

### DIFF
--- a/apps/web/components/dashboard/bottom-nav.tsx
+++ b/apps/web/components/dashboard/bottom-nav.tsx
@@ -60,6 +60,7 @@ export function BottomNav({ user, userType = "owner", planBadge = "none", trialD
             <Link
               key={item.href}
               href={item.href}
+              prefetch
               className={cn(
                 "flex flex-col items-center gap-0.5 px-3 py-1 text-xs transition",
                 isActive ? "text-primary" : "text-muted-foreground"
@@ -75,6 +76,7 @@ export function BottomNav({ user, userType = "owner", planBadge = "none", trialD
         {userType === "owner" && (
           <Link
             href="/dashboard/settings"
+            prefetch
             className={cn(
               "flex flex-col items-center gap-0.5 px-3 py-1 text-xs transition",
               profileActive ? "text-primary" : "text-muted-foreground"
@@ -120,6 +122,7 @@ export function BottomNav({ user, userType = "owner", planBadge = "none", trialD
                   <Link
                     key={item.href}
                     href={item.href}
+                    prefetch
                     onClick={() => setOpen(false)}
                     className={cn(
                       "flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition",

--- a/apps/web/components/dashboard/sidebar.tsx
+++ b/apps/web/components/dashboard/sidebar.tsx
@@ -50,6 +50,7 @@ export function Sidebar({ user, userType = "owner", planBadge = "none", trialDay
             <Link
               key={item.href}
               href={item.href}
+              prefetch
               className={cn(
                 "flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition",
                 isActive


### PR DESCRIPTION
## Summary
- **Prefetch**: Add `prefetch` to all navigation links (sidebar, bottom nav, menu sheet) for instant page transitions
- **Android fix**: Remove `ScrollView` wrapper around WebView that caused UI freeze on touch events
- **Sign out fix**: Redirect to `/login` instead of `/` so mobile WebView detects logout properly
- **Hydration fix**: Use `<style>` tag instead of inline styles to prevent React hydration mismatch

Closes #40

## CI Pre-check
| Check | Status |
|-------|--------|
| lint (web + mobile) | ✅ passed |
| typecheck (web + mobile) | ✅ passed |
| knip | ✅ passed |
| pruny | ✅ passed |

## Test plan
- [ ] Sign out works on mobile — returns to native login screen
- [ ] Nav links load instantly (prefetched)
- [ ] Android Menu button doesn't freeze UI
- [ ] No hydration mismatch errors in dev mode