### PR TITLE
fix: filter out low-quality bug reports with client-side validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.8.2](https://github.com/WebNaresh/glitchgrab/compare/v1.8.1...v1.8.2) (2026-04-09)
+
+### Bug Fixes
+
+* **api:** detect localhost via body pageUrl instead of unreliable Origin/Referer headers ([95a7cba](https://github.com/WebNaresh/glitchgrab/commit/95a7cba5024875b9c3126595c28ba374e242cc73))
+
 ## [1.8.1](https://github.com/WebNaresh/glitchgrab/compare/v1.8.0...v1.8.1) (2026-04-09)
 
 ### Bug Fixes

--- a/apps/web/app/dashboard/bug-chat.tsx
+++ b/apps/web/app/dashboard/bug-chat.tsx
@@ -23,6 +23,46 @@ import {
 import { toast } from "sonner";
 import { InteractiveQuestions } from "@/components/dashboard/interactive-questions";
 
+/** Validate that report text is meaningful — rejects gibberish, throwaway words, random chars */
+function isLowQualityText(text: string): string | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null; // empty is OK (screenshot-only)
+
+  // Common throwaway / test inputs
+  const throwaway =
+    /^(done|ok|yes|no|hi|hello|hey|test|testing|asdf|qwerty|abc|xyz|foo|bar|baz|lol|lmao|idk|bruh|nice|cool|wow|sup|yo|nah|yep|nope|thanks|thx|ty|k|kk|hmm|hm|na|mm|mhm|aight|bet|gg|wp|rip|omg|pls|plz)$/i;
+  if (throwaway.test(trimmed)) {
+    return "Please describe the actual issue you're experiencing";
+  }
+
+  // Repeated characters (e.g., "aaaaaa", "xxxxxxx")
+  if (/(.)\1{4,}/.test(trimmed)) {
+    return "Please provide a meaningful bug description";
+  }
+
+  // Gibberish detection: if the text is mostly letters, check vowel ratio
+  const letters = trimmed.replace(/[^a-zA-Z]/g, "");
+  if (letters.length >= 4) {
+    const vowels = letters.replace(/[^aeiouAEIOU]/g, "").length;
+    const vowelRatio = vowels / letters.length;
+    if (vowelRatio < 0.08) {
+      return "That doesn't look like a valid bug description";
+    }
+  }
+
+  // Single short word that isn't a known tech term
+  const words = trimmed.split(/\s+/).filter((w) => w.length > 0);
+  if (words.length === 1 && trimmed.length < 10) {
+    const techTerms =
+      /^(crash|error|bug|fail|broken|slow|freeze|lag|404|500|null|undefined|nan|timeout|overflow|leak|cors|oom)$/i;
+    if (!techTerms.test(trimmed)) {
+      return "Please provide more detail about the issue";
+    }
+  }
+
+  return null;
+}
+
 /** Compress an image file client-side to stay under Vercel's 4.5MB payload limit */
 async function compressImage(
   file: File,
@@ -501,6 +541,13 @@ export function BugChat({
 
     if (!selectedRepo) {
       toast.error("Select a repo first");
+      return;
+    }
+
+    // Validate text quality — reject gibberish / throwaway words
+    const qualityError = isLowQualityText(input);
+    if (qualityError) {
+      toast.error(qualityError);
       return;
     }
 

--- a/packages/sdk-nextjs/src/report-dialog.tsx
+++ b/packages/sdk-nextjs/src/report-dialog.tsx
@@ -27,6 +27,42 @@ function getTheme(dark: boolean) {
     : { bg: "#ffffff", bgSecondary: "#f4f4f5", border: "#e4e4e7", text: "#18181b", textMuted: "#71717a", accent: "#0891b2", accentText: "#ffffff", inputBg: "#fafafa", inputBorder: "#d4d4d8" };
 }
 
+/** Validate that report text is meaningful — rejects gibberish, throwaway words, random chars */
+function isLowQualityText(text: string): string | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+
+  const throwaway =
+    /^(done|ok|yes|no|hi|hello|hey|test|testing|asdf|qwerty|abc|xyz|foo|bar|baz|lol|lmao|idk|bruh|nice|cool|wow|sup|yo|nah|yep|nope|thanks|thx|ty|k|kk|hmm|hm|na|mm|mhm|aight|bet|gg|wp|rip|omg|pls|plz)$/i;
+  if (throwaway.test(trimmed)) {
+    return "Please describe the actual issue you're experiencing";
+  }
+
+  if (/(.)\1{4,}/.test(trimmed)) {
+    return "Please provide a meaningful description";
+  }
+
+  const letters = trimmed.replace(/[^a-zA-Z]/g, "");
+  if (letters.length >= 4) {
+    const vowels = letters.replace(/[^aeiouAEIOU]/g, "").length;
+    const vowelRatio = vowels / letters.length;
+    if (vowelRatio < 0.08) {
+      return "That doesn't look like a valid description";
+    }
+  }
+
+  const words = trimmed.split(/\s+/).filter((w) => w.length > 0);
+  if (words.length === 1 && trimmed.length < 10) {
+    const techTerms =
+      /^(crash|error|bug|fail|broken|slow|freeze|lag|404|500|null|undefined|nan|timeout|overflow|leak|cors|oom)$/i;
+    if (!techTerms.test(trimmed)) {
+      return "Please provide more detail about the issue";
+    }
+  }
+
+  return null;
+}
+
 interface ReportDialogProps {
   report: UseGlitchgrabReturn["report"];
   types?: ReportType[];
@@ -59,6 +95,7 @@ export function ReportDialog({
   const [step, setStep] = useState(1);
   const [reportType, setReportType] = useState<ReportType>("BUG");
   const [severity, setSeverity] = useState<ReportSeverity>("medium");
+  const [validationError, setValidationError] = useState<string | null>(null);
 
   const availableTypes: ReportType[] = types ?? ["BUG", "FEATURE_REQUEST", "QUESTION", "OTHER"];
 
@@ -151,11 +188,19 @@ export function ReportDialog({
     setStep(1);
     setReportType("BUG");
     setSeverity("medium");
+    setValidationError(null);
   };
 
   const handleSubmit = async () => {
     try {
       if (!description.trim() || isSubmitting) return;
+
+      const qualityError = isLowQualityText(description);
+      if (qualityError) {
+        setValidationError(qualityError);
+        setStep(2);
+        return;
+      }
 
       setIsSubmitting(true);
       const metadata: Record<string, string> = {};
@@ -363,7 +408,7 @@ export function ReportDialog({
                     <>
                       <textarea
                         value={description}
-                        onChange={(e) => setDescription(e.target.value)}
+                        onChange={(e) => { setDescription(e.target.value); if (validationError) setValidationError(null); }}
                         placeholder={getPlaceholder(reportType)}
                         style={{
                           width: "100%",
@@ -413,9 +458,19 @@ export function ReportDialog({
                           </div>
                         </div>
                       )}
+                      {validationError && (
+                        <p style={{ color: "#ef4444", fontSize: "12px", marginTop: "6px" }}>
+                          {validationError}
+                        </p>
+                      )}
                       <button
                         type="button"
-                        onClick={() => setStep(3)}
+                        onClick={() => {
+                          const err = isLowQualityText(description);
+                          if (err) { setValidationError(err); return; }
+                          setValidationError(null);
+                          setStep(3);
+                        }}
                         disabled={!description.trim()}
                         style={{
                           marginTop: "12px",


### PR DESCRIPTION
## Summary
- Adds `isLowQualityText()` client-side validation to both the **dashboard chat** and **SDK report dialog**
- Rejects throwaway words ("done", "ok", "test", "asdf"), repeated characters ("aaaaaa"), gibberish with abnormal vowel ratios ("vachajdj", "vsjsjjs"), and single non-technical short words
- Dashboard shows a toast error; SDK shows inline red error text below the textarea
- Screenshot-only submissions remain unaffected

Closes #82

## Test plan
- [ ] Submit "done", "vachajdj", "vsjsjjs" in dashboard chat — should show toast error
- [ ] Submit "done" in SDK report dialog step 2 — should show red validation message
- [ ] Submit "crash", "error", "timeout" — should pass through (known tech terms)
- [ ] Submit screenshot-only (no text) — should still work
- [ ] Submit a real bug description — should work normally
- [ ] Type gibberish, see error, then fix text — error should clear on retype