### PR TITLE
fix(sdk): skip keepalive for large payloads to avoid 64KB browser limit

### DIFF
--- a/packages/sdk-nextjs/src/utils.ts
+++ b/packages/sdk-nextjs/src/utils.ts
@@ -86,13 +86,16 @@ export async function sendReport(
       Authorization: `Bearer ${payload.token}`,
     };
 
+    // keepalive has a 64KB body limit in browsers — skip it for large payloads (e.g., screenshots)
+    const useKeepalive = body.length < 60_000;
+
     for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
       try {
         const response = await fetch(url, {
           method: "POST",
           headers,
           body,
-          keepalive: true,
+          ...(useKeepalive ? { keepalive: true } : {}),
         });
 
         if (response.ok) {


### PR DESCRIPTION
## Problem

Reports with screenshots silently fail because `fetch` with `keepalive: true` enforces a **64KB body limit** in browsers. A base64 JPEG screenshot easily exceeds this, so the request never reaches the server.

## Fix

Only use `keepalive: true` when the serialized body is under 60KB. For larger payloads (reports with screenshots), skip keepalive — the user is still on the page so it's not needed.

## Test

1. Open any Next.js app using the SDK
2. Click report bug, add a screenshot, click Send Report
3. Report should now successfully reach the API