### PR TITLE
fix(sdk): preserve envelope success flag in sendReport result

### DIFF
--- a/packages/sdk-nextjs/src/utils.ts
+++ b/packages/sdk-nextjs/src/utils.ts
@@ -99,8 +99,11 @@ export async function sendReport(
         });
 
         if (response.ok) {
-          const data = (await response.json()) as { success: boolean; data?: ReportResult };
-          return data.data ?? { success: data.success };
+          const envelope = (await response.json()) as {
+            success: boolean;
+            data?: Omit<ReportResult, "success">;
+          };
+          return { success: envelope.success, ...(envelope.data ?? {}) };
         }
 
         if (response.status >= 400 && response.status < 500 && response.status !== 429) {


### PR DESCRIPTION
## Summary

The SDK's `sendReport` was unwrapping the API envelope as `data.data` and discarding the top-level `success` flag. Since the API uses the documented `{ success, data }` shape, this meant every successful response returned a `ReportResult` with `success: undefined` — even though `ReportResult.success` is declared as required.

This broke any consumer gating on `result.success`, e.g. `onReportSent` callbacks:

```ts
onReportSent={(result) => {
  if (result?.success) {        // always falsy — redirect never fires
    router.push("/settings?tab=support");
  }
}}
```

## Fix

Merge the envelope's `success` into the returned object so the shape matches the declared `ReportResult` type in both dev (localhost bypass) and prod (GitHub issue created) responses.

## Test plan
- [x] SDK builds cleanly
- [ ] Verify in a consumer app: `onReportSent` receives `{ success: true, ... }` in dev mode
- [ ] Verify in prod: `onReportSent` still receives `reportId`, `issueUrl`, `issueNumber` alongside `success: true`