### PR TITLE
ci: switch all workflows to self-hosted runner

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   ci:
     name: Lint, Typecheck, Test & Build
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     env:
       NEXT_POSTGRES_URL: "postgresql://fake:fake@localhost:5432/fake"

--- a/.github/workflows/claude-auto-fix.yml
+++ b/.github/workflows/claude-auto-fix.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   auto-fix:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Trigger Vercel Deploy Hook
         run: curl -s -X POST "${{ secrets.VERCEL_DEPLOY_HOOK }}"

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
 
     steps:


### PR DESCRIPTION
## Summary
- Switch all 7 GitHub Actions workflows from `ubuntu-latest` to `self-hosted`
- Affects: ci, claude, claude-auto-fix, publish-sdk, build-android, release, deploy-web

## Test plan
- [ ] Self-hosted runner is online and picks up jobs
- [ ] Runner has Bun, Node, and (for build-android) Android SDK + JDK installed
- [ ] CI workflow passes end-to-end on the self-hosted runner
- [ ] build-android produces a valid APK artifact