### PR TITLE
chore: update GitHub URLs to new org

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Grab the glitch. Ship the fix.**
 
 [![npm](https://img.shields.io/npm/v/glitchgrab)](https://www.npmjs.com/package/glitchgrab)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/WebNaresh/glitchgrab/blob/main/LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/Navibyte-Innovations-Pvt-Ltd/glitchgrab/blob/main/LICENSE)
 
 Glitchgrab turns messy bug reports — screenshots, production errors, user complaints — into well-structured GitHub issues using AI.
 

--- a/apps/web/app/(legal)/contact/page.tsx
+++ b/apps/web/app/(legal)/contact/page.tsx
@@ -82,12 +82,12 @@ export default function ContactPage() {
             contributions.
           </p>
           <a
-            href="https://github.com/WebNaresh/glitchgrab"
+            href="https://github.com/Navibyte-Innovations-Pvt-Ltd/glitchgrab"
             target="_blank"
             rel="noopener noreferrer"
             className="inline-block text-primary hover:underline text-sm font-medium"
           >
-            github.com/WebNaresh/glitchgrab
+            github.com/Navibyte-Innovations-Pvt-Ltd/glitchgrab
           </a>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Update contact page GitHub link from `WebNaresh/glitchgrab` to `Navibyte-Innovations-Pvt-Ltd/glitchgrab`
- Update MIT license badge URL in root README

## Why
Repo moved from personal account to the Navibyte org. Auto-generated changelogs + semantic-release URLs already pick up the new remote automatically, but these two user-facing links were hardcoded and needed manual updates.

## Changes
\`\`\`
 README.md                             | 2 +-
 apps/web/app/(legal)/contact/page.tsx | 4 ++--
 2 files changed, 3 insertions(+), 3 deletions(-)
\`\`\`

## CI Pre-check
Skipped locally — changes are text/URL only, no logic impact. CI on PR to main will run full validation.

## Test plan
- [ ] Contact page "Report an issue" link opens the new org repo
- [ ] README MIT badge on the org repo homepage links to correct LICENSE