### PR TITLE
feat(repos): support org repos, transfers, and renames

### DIFF
--- a/apps/web/app/api/v1/repos/github/route.ts
+++ b/apps/web/app/api/v1/repos/github/route.ts
@@ -8,10 +8,13 @@ interface GitHubRepo {
   id: number;
   full_name: string;
   name: string;
-  owner: { login: string };
+  owner: { login: string; type: "User" | "Organization" };
   private: boolean;
   description: string | null;
 }
+
+const PER_PAGE = 100;
+const MAX_PAGES = 10;
 
 export async function GET() {
   const session = await auth();
@@ -38,33 +41,59 @@ export async function GET() {
     );
   }
 
-  const response = await fetch(
-    "https://api.github.com/user/repos?per_page=100&sort=updated",
-    {
-      headers: {
-        Authorization: `Bearer ${account.access_token}`,
-        Accept: "application/vnd.github+json",
-      },
-    }
-  );
+  const headers = {
+    Authorization: `Bearer ${account.access_token}`,
+    Accept: "application/vnd.github+json",
+  };
 
-  if (!response.ok) {
-    return NextResponse.json(
-      { success: false, error: "Failed to fetch repos from GitHub" },
-      { status: response.status }
+  const allGhRepos: GitHubRepo[] = [];
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const response = await fetch(
+      `https://api.github.com/user/repos?per_page=${PER_PAGE}&page=${page}&sort=updated&affiliation=owner,collaborator,organization_member`,
+      { headers, cache: "no-store" }
     );
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { success: false, error: "Failed to fetch repos from GitHub" },
+        { status: response.status }
+      );
+    }
+
+    const batch: GitHubRepo[] = await response.json();
+    allGhRepos.push(...batch);
+    if (batch.length < PER_PAGE) break;
   }
 
-  const ghRepos: GitHubRepo[] = await response.json();
-
-  const repos = ghRepos.map((repo) => ({
+  const repos = allGhRepos.map((repo) => ({
     githubId: repo.id,
     fullName: repo.full_name,
     name: repo.name,
     owner: repo.owner.login,
+    ownerType: repo.owner.type === "Organization" ? "org" : "user",
     isPrivate: repo.private,
     description: repo.description,
   }));
 
-  return NextResponse.json({ success: true, data: repos });
+  const accountsMap = new Map<string, "user" | "org">();
+  for (const repo of repos) {
+    if (!accountsMap.has(repo.owner)) {
+      accountsMap.set(repo.owner, repo.ownerType as "user" | "org");
+    }
+  }
+  const accounts = Array.from(accountsMap, ([login, type]) => ({ login, type }))
+    .sort((a, b) => {
+      if (a.type !== b.type) return a.type === "user" ? -1 : 1;
+      return a.login.localeCompare(b.login);
+    });
+
+  const clientId = process.env.GITHUB_CLIENT_ID;
+  const connectionUrl = clientId
+    ? `https://github.com/settings/connections/applications/${clientId}`
+    : "https://github.com/settings/applications";
+
+  return NextResponse.json({
+    success: true,
+    data: { repos, accounts, connectionUrl },
+  });
 }

--- a/apps/web/app/dashboard/repos/actions.ts
+++ b/apps/web/app/dashboard/repos/actions.ts
@@ -8,6 +8,83 @@ const WEBHOOK_URL = process.env.NEXTAUTH_URL
   ? `${process.env.NEXTAUTH_URL}/api/v1/github/webhook`
   : "https://glitchgrab.dev/api/v1/github/webhook";
 
+export async function resyncRepo(repoId: string): Promise<{
+  fullName: string;
+  owner: string;
+  name: string;
+  changed: boolean;
+}> {
+  const session = await auth();
+  if (!session?.user?.id) throw new Error("Unauthorized");
+
+  const repo = await prisma.repo.findFirst({
+    where: { id: repoId, userId: session.user.id },
+  });
+  if (!repo) throw new Error("Repo not found");
+
+  const account = await prisma.account.findFirst({
+    where: { userId: session.user.id, provider: "github" },
+  });
+  if (!account?.access_token) throw new Error("GitHub account not linked");
+
+  const res = await fetch(
+    `https://api.github.com/repositories/${repo.githubId}`,
+    {
+      headers: {
+        Authorization: `Bearer ${account.access_token}`,
+        Accept: "application/vnd.github+json",
+      },
+      cache: "no-store",
+    }
+  );
+
+  if (!res.ok) {
+    throw new Error(
+      res.status === 404
+        ? "Repo not accessible — was it deleted or access revoked?"
+        : "Failed to fetch repo from GitHub"
+    );
+  }
+
+  const gh = (await res.json()) as {
+    full_name: string;
+    name: string;
+    owner: { login: string };
+    private: boolean;
+  };
+
+  const changed =
+    gh.full_name !== repo.fullName ||
+    gh.owner.login !== repo.owner ||
+    gh.name !== repo.name;
+
+  if (changed) {
+    await prisma.repo.update({
+      where: { id: repo.id },
+      data: {
+        fullName: gh.full_name,
+        owner: gh.owner.login,
+        name: gh.name,
+        isPrivate: gh.private,
+      },
+    });
+
+    // Re-setup webhook on the new location (non-blocking)
+    setupGitHubWebhook(session.user.id, gh.owner.login, gh.name).catch((err) =>
+      console.error("Failed to setup webhook after resync:", err)
+    );
+  }
+
+  revalidatePath("/dashboard/repos");
+
+  return {
+    fullName: gh.full_name,
+    owner: gh.owner.login,
+    name: gh.name,
+    changed,
+  };
+}
+
 export async function connectRepo(
   githubId: number,
   fullName: string,

--- a/apps/web/app/dashboard/repos/connect-repo-dialog.tsx
+++ b/apps/web/app/dashboard/repos/connect-repo-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { signIn } from "next-auth/react";
 import axios from "axios";
 import {
   Dialog,
@@ -12,7 +13,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Check, Github, Loader2, Plus, Search } from "lucide-react";
+import { Building2, Check, Github, Loader2, Plus, RefreshCw, Search } from "lucide-react";
 import { toast } from "sonner";
 import { connectRepo } from "./actions";
 
@@ -21,23 +22,43 @@ interface GitHubRepo {
   fullName: string;
   name: string;
   owner: string;
+  ownerType: "user" | "org";
   isPrivate: boolean;
   description: string | null;
+}
+
+interface GitHubAccount {
+  login: string;
+  type: "user" | "org";
+}
+
+interface GitHubReposResponse {
+  repos: GitHubRepo[];
+  accounts: GitHubAccount[];
+  connectionUrl: string;
 }
 
 export function ConnectRepoDialog() {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
+  const [accountFilter, setAccountFilter] = useState<string>("all");
   const queryClient = useQueryClient();
 
-  const { data: repos = [], isLoading, isFetching } = useQuery<GitHubRepo[]>({
+  const { data, isLoading, isFetching, refetch } = useQuery<GitHubReposResponse>({
     queryKey: ["github-repos"],
     queryFn: async () => {
       const { data } = await axios.get("/api/v1/repos/github");
       return data.data;
     },
     enabled: open,
+    refetchOnMount: "always",
+    refetchOnWindowFocus: true,
   });
+
+  const repos = data?.repos ?? [];
+  const accounts = data?.accounts ?? [];
+  const orgAccounts = accounts.filter((a) => a.type === "org");
+  const connectionUrl = data?.connectionUrl;
 
   const { data: connectedRepos } = useQuery<{ ownRepos: { githubId: number }[] }>({
     queryKey: ["repos"],
@@ -71,12 +92,32 @@ export function ConnectRepoDialog() {
     },
   });
 
-  const filtered = repos.filter((repo) =>
-    repo.fullName.toLowerCase().includes(search.toLowerCase())
-  );
+  const filtered = repos.filter((repo) => {
+    const matchesAccount = accountFilter === "all" || repo.owner === accountFilter;
+    const matchesSearch = repo.fullName.toLowerCase().includes(search.toLowerCase());
+    return matchesAccount && matchesSearch;
+  });
+
+  const handleOpenConnections = () => {
+    if (!connectionUrl) return;
+    window.open(connectionUrl, "_blank", "noopener,noreferrer");
+  };
+
+  const handleReconnectGitHub = () => {
+    signIn("github", { callbackUrl: "/dashboard/repos" });
+  };
 
   return (
-    <Dialog open={open} onOpenChange={(v) => { setOpen(v); if (v) setSearch(""); }}>
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        setOpen(v);
+        if (v) {
+          setSearch("");
+          setAccountFilter("all");
+        }
+      }}
+    >
       <DialogTrigger
         render={
           <Button
@@ -110,10 +151,73 @@ export function ConnectRepoDialog() {
             onChange={(e) => setSearch(e.target.value)}
             className="pl-9 font-mono text-sm"
           />
-          {isFetching && !isLoading && (
+          {isFetching && !isLoading ? (
             <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-muted-foreground" />
+          ) : (
+            !isLoading && (
+              <button
+                type="button"
+                onClick={() => refetch()}
+                title="Refresh repo list"
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <RefreshCw className="h-4 w-4" />
+              </button>
+            )
           )}
         </div>
+
+        {!isLoading && (
+          <div className="flex items-center gap-1.5 flex-wrap">
+            <button
+              type="button"
+              onClick={() => setAccountFilter("all")}
+              className={`font-mono text-[10px] uppercase tracking-wider px-2 py-1 rounded border transition-colors ${
+                accountFilter === "all"
+                  ? "bg-primary/10 border-primary/40 text-primary"
+                  : "bg-card border-border text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              all
+            </button>
+            {orgAccounts.map((acc) => {
+              const isActive = accountFilter === acc.login;
+              return (
+                <button
+                  type="button"
+                  key={acc.login}
+                  onClick={() => setAccountFilter(acc.login)}
+                  className={`inline-flex items-center gap-1.5 font-mono text-[10px] px-2 py-1 rounded border transition-colors ${
+                    isActive
+                      ? "bg-primary/10 border-primary/40 text-primary"
+                      : "bg-card border-border text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  <Building2 className="h-3 w-3" />
+                  {acc.login}
+                </button>
+              );
+            })}
+            <button
+              type="button"
+              onClick={handleOpenConnections}
+              className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-wider px-2 py-1 rounded border border-dashed border-border text-muted-foreground hover:text-foreground hover:border-primary/40 transition-colors"
+              title="Open GitHub to grant Glitchgrab access to another organization"
+            >
+              <Plus className="h-3 w-3" />
+              add org
+            </button>
+            <button
+              type="button"
+              onClick={handleReconnectGitHub}
+              className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-wider px-2 py-1 rounded border border-dashed border-border text-muted-foreground hover:text-foreground hover:border-primary/40 transition-colors ml-auto"
+              title="Reconnect GitHub to refresh org access"
+            >
+              <RefreshCw className="h-3 w-3" />
+              reconnect
+            </button>
+          </div>
+        )}
 
         {!isLoading && repos.length > 0 && (
           <div className="font-mono text-[10px] text-muted-foreground uppercase tracking-widest flex items-center justify-between px-1">
@@ -132,15 +236,26 @@ export function ConnectRepoDialog() {
               <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
             </div>
           ) : filtered.length === 0 ? (
-            <div className="border border-dashed border-border rounded p-8 flex flex-col items-center text-center">
-              <div className="w-10 h-10 rounded-full bg-card border border-border flex items-center justify-center mb-3">
+            <div className="border border-dashed border-border rounded p-6 flex flex-col items-center text-center gap-3">
+              <div className="w-10 h-10 rounded-full bg-card border border-border flex items-center justify-center">
                 <Github className="h-4 w-4 text-muted-foreground" />
               </div>
               <p className="font-mono text-xs text-muted-foreground">
                 {repos.length === 0
                   ? "no repos found on your GitHub account"
-                  : "no repos match your search"}
+                  : accountFilter !== "all"
+                    ? `no repos under ${accountFilter}`
+                    : "no repos match your search"}
               </p>
+              {connectionUrl && (
+                <button
+                  type="button"
+                  onClick={handleOpenConnections}
+                  className="font-mono text-[10px] uppercase tracking-wider text-primary hover:underline"
+                >
+                  missing an organization? grant access →
+                </button>
+              )}
             </div>
           ) : (
             filtered.map((repo) => {
@@ -169,6 +284,11 @@ export function ConnectRepoDialog() {
                       <span className="text-sm font-medium text-foreground break-all">
                         {repo.fullName}
                       </span>
+                      {repo.ownerType === "org" && (
+                        <span className="px-1.5 py-px rounded bg-primary/10 text-[9px] font-mono text-primary uppercase border border-primary/30">
+                          org
+                        </span>
+                      )}
                       <span className="px-1.5 py-px rounded bg-muted text-[9px] font-mono text-muted-foreground uppercase border border-border">
                         {repo.isPrivate ? "private" : "public"}
                       </span>

--- a/apps/web/app/dashboard/repos/repos-list.tsx
+++ b/apps/web/app/dashboard/repos/repos-list.tsx
@@ -1,14 +1,17 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 import {
   ChevronRight,
   GitFork,
   Github,
   Loader2,
+  RefreshCw,
   Users,
 } from "lucide-react";
+import { toast } from "sonner";
+import { resyncRepo } from "./actions";
 
 interface Repo {
   id: string;
@@ -110,6 +113,23 @@ function RepoRow({ repo, kind }: { repo: Repo; kind: "own" | "shared" }) {
     ? repo.fullName.split("/")
     : ["—", repo.fullName];
 
+  const queryClient = useQueryClient();
+
+  const { mutate: syncRepo, isPending: isSyncing } = useMutation({
+    mutationFn: () => resyncRepo(repo.id),
+    onSuccess: (result) => {
+      if (result.changed) {
+        toast.success(`Synced: now ${result.fullName}`);
+      } else {
+        toast.info("Already up to date");
+      }
+      queryClient.invalidateQueries({ queryKey: ["repos"] });
+    },
+    onError: (err) => {
+      toast.error(err instanceof Error ? err.message : "Failed to sync repo");
+    },
+  });
+
   const stripClass =
     kind === "shared"
       ? "bg-primary shadow-[0_0_8px_rgba(34,211,238,0.4)]"
@@ -150,9 +170,31 @@ function RepoRow({ repo, kind }: { repo: Repo; kind: "own" | "shared" }) {
       <div className="hidden sm:block font-mono text-[11px] text-muted-foreground tabular-nums mr-8">
         {repo.reports} {repo.reports === 1 ? "report" : "reports"}
       </div>
-      <div className="flex items-center gap-1.5 px-2 py-1 rounded bg-primary/10 border border-primary/30 text-primary font-mono text-[10px] uppercase tracking-wider">
-        <div className="w-1.5 h-1.5 rounded-full bg-primary animate-pulse" />
-        {kind === "shared" ? "shared" : "connected"}
+      <div className="flex items-center gap-2">
+        {kind === "own" && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              syncRepo();
+            }}
+            disabled={isSyncing}
+            title="Sync with GitHub (detects renames & transfers)"
+            className="inline-flex items-center gap-1 px-2 py-1 rounded border border-border bg-card text-muted-foreground hover:text-foreground hover:border-primary/40 font-mono text-[10px] uppercase tracking-wider transition-colors disabled:opacity-50"
+          >
+            {isSyncing ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <RefreshCw className="h-3 w-3" />
+            )}
+            sync
+          </button>
+        )}
+        <div className="flex items-center gap-1.5 px-2 py-1 rounded bg-primary/10 border border-primary/30 text-primary font-mono text-[10px] uppercase tracking-wider">
+          <div className="w-1.5 h-1.5 rounded-full bg-primary animate-pulse" />
+          {kind === "shared" ? "shared" : "connected"}
+        </div>
       </div>
       <div className="flex justify-end pr-2 text-muted-foreground opacity-0 -translate-x-3 transition-all duration-200 group-hover:opacity-100 group-hover:translate-x-0">
         <ChevronRight className="h-4 w-4" />

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -33,9 +33,21 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     signIn: "/login",
   },
   callbacks: {
-    jwt({ token, user }) {
+    async jwt({ token, user, account }) {
       if (user) {
         token.id = user.id;
+      }
+      if (account?.provider === "github" && account.access_token && token.id) {
+        await prisma.account.updateMany({
+          where: { userId: token.id as string, provider: "github" },
+          data: {
+            access_token: account.access_token,
+            token_type: account.token_type,
+            scope: account.scope,
+            refresh_token: account.refresh_token,
+            expires_at: account.expires_at,
+          },
+        });
       }
       return token;
     },


### PR DESCRIPTION
## Summary
- Paginate GitHub repos (up to 1000) so users with >100 repos see all of them
- Refresh stored GitHub access_token on every sign-in — previously NextAuth silently reused stale tokens, so org approvals never took effect
- Add org filter chips + RECONNECT + ADD ORG CTAs in Connect Repo dialog — no GitHub jargon, no hunting through settings
- Add SYNC button on each connected repo row — detects transfers/renames via GitHub's immutable repo id and updates owner/name in place (preserves tokens + reports + webhooks)

## Changes
 apps/web/app/api/v1/repos/github/route.ts          |  65 +++++++---
 apps/web/app/dashboard/repos/actions.ts            |  77 +++++++++++
 apps/web/app/dashboard/repos/connect-repo-dialog.tsx | 140 +++++++++++++++++--
 apps/web/app/dashboard/repos/repos-list.tsx        |  50 +++++++-
 apps/web/lib/auth.ts                               |  14 ++-

## Why
User transferred a personal repo to an org and lost visibility of the repo in Glitchgrab. Root causes:
1. Dialog capped at 100 repos with no pagination
2. Org-owned repos required OAuth approval + a fresh token — NextAuth wasn't refreshing tokens on re-signin
3. No way to update the stored path after a transfer without disconnecting (which would delete reports history)

## Test plan
- [ ] Open Connect Repo → see pagination count reflect all repos (e.g. 239/239)
- [ ] Click RECONNECT → GitHub re-auth → org repos now appear
- [ ] Click ADD ORG → lands on GitHub OAuth app page to grant org access
- [ ] Org-filter chip isolates repos to that org
- [ ] Click SYNC on a transferred repo → row updates to new owner/name, existing reports + tokens preserved
- [ ] SDK using the old token still posts issues to the new location after sync