### PR TITLE
fix(repos): surface specific GitHub errors in repo sync

### DIFF
--- a/apps/web/app/dashboard/repos/actions.ts
+++ b/apps/web/app/dashboard/repos/actions.ts
@@ -39,11 +39,27 @@ export async function resyncRepo(repoId: string): Promise<{
   );
 
   if (!res.ok) {
-    throw new Error(
-      res.status === 404
-        ? "Repo not accessible — was it deleted or access revoked?"
-        : "Failed to fetch repo from GitHub"
+    const body = await res.text().catch(() => "");
+    console.error(
+      `[resyncRepo] GitHub ${res.status} for repo id=${repo.githubId} (${repo.fullName}):`,
+      body
     );
+    if (res.status === 404) {
+      throw new Error(
+        "Can't see this repo — if it was transferred to an org, click RECONNECT in Connect Repo dialog to refresh GitHub access"
+      );
+    }
+    if (res.status === 401) {
+      throw new Error(
+        "GitHub token expired — click RECONNECT in Connect Repo dialog to re-authenticate"
+      );
+    }
+    if (res.status === 403) {
+      throw new Error(
+        "GitHub denied access (rate limit or org OAuth policy). Click ADD ORG in Connect Repo dialog to grant access."
+      );
+    }
+    throw new Error(`Failed to fetch repo from GitHub (${res.status})`);
   }
 
   const gh = (await res.json()) as {


### PR DESCRIPTION
## Summary
- Surface distinct error messages in resyncRepo for 401/403/404/other GitHub responses
- Log full status + response body server-side so failures are diagnosable
- Guide users to RECONNECT or ADD ORG directly from the error toast

## Why
After merging #139, the SYNC button hit a generic "Failed to fetch repo from GitHub" when the stored OAuth token couldn't see a transferred repo. No indication of whether it was auth, permission, or missing repo.

## Changes
 apps/web/app/dashboard/repos/actions.ts | 24 ++++++++++++++++++------

## Test plan
- [ ] Sync a repo the token can't see → toast says to click RECONNECT
- [ ] Check server logs show GitHub status code + body
- [ ] Sync a valid transferred repo → succeeds as before