### PR TITLE
feat(sdk): surface visible feedback when SDK is misconfigured (closes #146)

### DIFF
--- a/packages/sdk-nextjs/README.md
+++ b/packages/sdk-nextjs/README.md
@@ -146,6 +146,27 @@ function FeedbackWidget() {
 
 Note: `openReportDialog()` requires a `<ReportButton>` to be mounted somewhere in the component tree. It triggers the same modal with screenshot capture.
 
+### Misconfiguration behavior
+
+If the provider is rendered without a token (e.g. `NEXT_PUBLIC_GLITCHGRAB_TOKEN` is missing in your deployment), the SDK won't silently no-op:
+
+- `useGlitchgrab()` **does not throw** — it returns stub methods so your components keep rendering.
+- Calling `openReportDialog()`, `reportBug()`, or `report()` shows a visible toast in the browser and logs a `console.warn`.
+- `<ReportButton>` hides itself automatically.
+
+Use `isGlitchgrabReady()` to gate your own trigger buttons:
+
+```tsx
+import { useGlitchgrab, isGlitchgrabReady } from "glitchgrab";
+
+function SupportButton() {
+  const { openReportDialog } = useGlitchgrab();
+  const ready = isGlitchgrabReady();
+  if (!ready) return null;
+  return <button onClick={() => openReportDialog()}>Report a bug</button>;
+}
+```
+
 ## Fetching Reports by User
 
 ### React hook (recommended)

--- a/packages/sdk-nextjs/src/__tests__/misconfigured.test.tsx
+++ b/packages/sdk-nextjs/src/__tests__/misconfigured.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act, renderHook } from "@testing-library/react";
+import { GlitchgrabProvider, useGlitchgrab, isGlitchgrabReady } from "../provider";
+import { __resetWarnToast } from "../warn-toast";
+
+describe("Glitchgrab misconfigured behavior", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    __resetWarnToast();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    document.body.innerHTML = "";
+  });
+
+  it("useGlitchgrab() does not throw when called outside a provider", () => {
+    const { result } = renderHook(() => useGlitchgrab());
+    expect(result.current).toBeDefined();
+    expect(result.current.token).toBe("");
+    expect(typeof result.current.openReportDialog).toBe("function");
+  });
+
+  it("useGlitchgrab() does not throw when provider has no token", () => {
+    function Probe() {
+      const gg = useGlitchgrab();
+      return <span data-testid="token">{gg.token || "empty"}</span>;
+    }
+    render(
+      <GlitchgrabProvider token="">
+        <Probe />
+      </GlitchgrabProvider>
+    );
+    expect(screen.getByTestId("token").textContent).toBe("empty");
+  });
+
+  it("isGlitchgrabReady() returns false with no provider", () => {
+    const { result } = renderHook(() => isGlitchgrabReady());
+    expect(result.current).toBe(false);
+  });
+
+  it("isGlitchgrabReady() returns false when token is missing", () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <GlitchgrabProvider token="">{children}</GlitchgrabProvider>
+    );
+    const { result } = renderHook(() => isGlitchgrabReady(), { wrapper });
+    expect(result.current).toBe(false);
+  });
+
+  it("isGlitchgrabReady() returns true when token is set", () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <GlitchgrabProvider token="gg_test_token">{children}</GlitchgrabProvider>
+    );
+    const { result } = renderHook(() => isGlitchgrabReady(), { wrapper });
+    expect(result.current).toBe(true);
+  });
+
+  it("openReportDialog() warns to console when misconfigured", () => {
+    function Trigger() {
+      const { openReportDialog } = useGlitchgrab();
+      return <button onClick={() => openReportDialog()}>open</button>;
+    }
+    render(
+      <GlitchgrabProvider token="">
+        <Trigger />
+      </GlitchgrabProvider>
+    );
+    act(() => {
+      screen.getByRole("button", { name: "open" }).click();
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("isn't configured")
+    );
+  });
+
+  it("openReportDialog() renders a visible toast when misconfigured", () => {
+    function Trigger() {
+      const { openReportDialog } = useGlitchgrab();
+      return <button onClick={() => openReportDialog()}>open</button>;
+    }
+    render(
+      <GlitchgrabProvider token="">
+        <Trigger />
+      </GlitchgrabProvider>
+    );
+    act(() => {
+      screen.getByRole("button", { name: "open" }).click();
+    });
+    const toast = document.getElementById("glitchgrab-misconfig-toast");
+    expect(toast).not.toBeNull();
+    expect(toast?.textContent).toContain("Glitchgrab not configured");
+  });
+
+  it("console.warn is deduped across repeated calls", () => {
+    function Trigger() {
+      const { openReportDialog } = useGlitchgrab();
+      return <button onClick={() => openReportDialog()}>open</button>;
+    }
+    render(
+      <GlitchgrabProvider token="">
+        <Trigger />
+      </GlitchgrabProvider>
+    );
+    const btn = screen.getByRole("button", { name: "open" });
+    act(() => {
+      btn.click();
+      btn.click();
+      btn.click();
+    });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("report() resolves to null and warns when misconfigured", async () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <GlitchgrabProvider token="">{children}</GlitchgrabProvider>
+    );
+    const { result } = renderHook(() => useGlitchgrab(), { wrapper });
+    const res = await result.current.report("BUG", "test");
+    expect(res).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/sdk-nextjs/src/index.ts
+++ b/packages/sdk-nextjs/src/index.ts
@@ -1,7 +1,7 @@
 "use client";
 
 // ─── Core (required) ─────────────────────────────────────
-export { GlitchgrabProvider, useGlitchgrab } from "./provider";
+export { GlitchgrabProvider, useGlitchgrab, isGlitchgrabReady } from "./provider";
 
 // ─── Optional Components ─────────────────────────────────
 export { ReportButton } from "./report-button";

--- a/packages/sdk-nextjs/src/provider.tsx
+++ b/packages/sdk-nextjs/src/provider.tsx
@@ -6,7 +6,7 @@ import {
   useRef,
   useEffect,
   useCallback,
-  useState,
+  useMemo,
 } from "react";
 import type {
   GlitchgrabProviderProps,
@@ -23,34 +23,71 @@ import {
   addBreadcrumb as addBreadcrumbInternal,
   getBreadcrumbs,
 } from "./breadcrumbs";
+import { warnMisconfigured } from "./warn-toast";
 
 const DEFAULT_BASE_URL = "https://www.glitchgrab.dev";
 
-const GlitchgrabContext = createContext<UseGlitchgrabReturn | null>(null);
+const MISCONFIG_MESSAGE =
+  "Bug reporting isn't configured — GlitchgrabProvider is missing a token.";
+
+interface InternalContextValue extends UseGlitchgrabReturn {
+  /** Internal flag — true when provider has a token and is fully wired. */
+  ready: boolean;
+}
+
+const DISABLED_CONTEXT: InternalContextValue = {
+  ready: false,
+  token: "",
+  baseUrl: DEFAULT_BASE_URL,
+  reportBug: async () => {
+    warnMisconfigured("reportBug", MISCONFIG_MESSAGE);
+    return null;
+  },
+  report: async () => {
+    warnMisconfigured("report", MISCONFIG_MESSAGE);
+    return null;
+  },
+  addBreadcrumb: () => {
+    // breadcrumbs without a token are a no-op, but safe — no warn needed
+  },
+  openReportDialog: () => {
+    warnMisconfigured("openReportDialog", MISCONFIG_MESSAGE);
+  },
+};
+
+const GlitchgrabContext = createContext<InternalContextValue | null>(null);
 
 /**
  * Hook to access Glitchgrab in your components.
  *
+ * Safe to call anywhere — does not throw. If the provider is missing or
+ * misconfigured (no token), the hook returns stub methods that log a
+ * visible warning when called.
+ *
  * @example
  * ```tsx
  * const { reportBug, report, addBreadcrumb } = useGlitchgrab();
- *
- * // Report a bug
  * reportBug("Login button crashes on mobile");
- *
- * // Report a feature request
- * report("FEATURE_REQUEST", "Add dark mode");
- *
- * // Add a custom breadcrumb
- * addBreadcrumb("User clicked checkout", { cartItems: "3" });
  * ```
  */
 export function useGlitchgrab(): UseGlitchgrabReturn {
   const ctx = useContext(GlitchgrabContext);
-  if (!ctx) {
-    throw new Error("useGlitchgrab must be used within a GlitchgrabProvider");
-  }
-  return ctx;
+  return ctx ?? DISABLED_CONTEXT;
+}
+
+/**
+ * Returns true if the Glitchgrab SDK is configured and ready to use.
+ * Useful for conditionally rendering a report button only when the SDK works.
+ *
+ * @example
+ * ```tsx
+ * const ready = isGlitchgrabReady();
+ * return ready ? <button onClick={openReportDialog}>Report</button> : null;
+ * ```
+ */
+export function isGlitchgrabReady(): boolean {
+  const ctx = useContext(GlitchgrabContext);
+  return ctx?.ready === true;
 }
 
 function GlitchgrabProviderInner({
@@ -68,14 +105,12 @@ function GlitchgrabProviderInner({
 }: GlitchgrabProviderProps) {
   const visitedPagesRef = useRef<string[]>([]);
 
-  // Initialize breadcrumbs
   useEffect(() => {
     if (enableBreadcrumbs) {
       initBreadcrumbs(maxBreadcrumbs);
     }
   }, [enableBreadcrumbs, maxBreadcrumbs]);
 
-  // Track page visits
   useEffect(() => {
     try {
       if (typeof window === "undefined") return;
@@ -121,7 +156,6 @@ function GlitchgrabProviderInner({
     }
   }, []);
 
-  // Unhandled errors and rejections — skip in development
   useEffect(() => {
     try {
       if (typeof window === "undefined") return;
@@ -260,17 +294,21 @@ function GlitchgrabProviderInner({
     }
   }, []);
 
+  const value = useMemo<InternalContextValue>(
+    () => ({
+      ready: true,
+      token,
+      baseUrl: baseUrl ?? DEFAULT_BASE_URL,
+      reportBug,
+      report,
+      addBreadcrumb,
+      openReportDialog,
+    }),
+    [token, baseUrl, reportBug, report, addBreadcrumb, openReportDialog]
+  );
+
   return (
-    <GlitchgrabContext.Provider
-      value={{
-        token,
-        baseUrl: baseUrl ?? DEFAULT_BASE_URL,
-        reportBug,
-        report,
-        addBreadcrumb,
-        openReportDialog,
-      }}
-    >
+    <GlitchgrabContext.Provider value={value}>
       <GlitchgrabErrorBoundary
         token={token}
         baseUrl={baseUrl}
@@ -286,8 +324,13 @@ function GlitchgrabProviderInner({
 }
 
 export function GlitchgrabProvider(props: GlitchgrabProviderProps) {
-  // No token = passthrough (SDK disabled)
-  if (!props.token) return <>{props.children}</>;
+  if (!props.token) {
+    return (
+      <GlitchgrabContext.Provider value={DISABLED_CONTEXT}>
+        {props.children}
+      </GlitchgrabContext.Provider>
+    );
+  }
 
   const resolvedProps = {
     ...props,
@@ -297,6 +340,10 @@ export function GlitchgrabProvider(props: GlitchgrabProviderProps) {
   try {
     return <GlitchgrabProviderInner {...resolvedProps} />;
   } catch {
-    return <>{props.children}</>;
+    return (
+      <GlitchgrabContext.Provider value={DISABLED_CONTEXT}>
+        {props.children}
+      </GlitchgrabContext.Provider>
+    );
   }
 }

--- a/packages/sdk-nextjs/src/report-button.tsx
+++ b/packages/sdk-nextjs/src/report-button.tsx
@@ -2,16 +2,7 @@
 
 import { useState, type CSSProperties, type ReactNode } from "react";
 import type { ReportButtonProps } from "./types";
-import { useGlitchgrab } from "./provider";
-
-/** Safe version of useGlitchgrab that returns null when outside provider */
-function useGlitchgrabSafe() {
-  try {
-    return useGlitchgrab();
-  } catch {
-    return null;
-  }
-}
+import { useGlitchgrab, isGlitchgrabReady } from "./provider";
 
 /**
  * Optional trigger button for opening the report dialog.
@@ -44,9 +35,10 @@ export function ReportButton({
   children?: (props: { onClick: () => void; capturing: boolean }) => ReactNode;
 }) {
   const [capturing, setCapturing] = useState(false);
-  const glitchgrab = useGlitchgrabSafe();
+  const glitchgrab = useGlitchgrab();
+  const ready = isGlitchgrabReady();
 
-  if (!glitchgrab) return null;
+  if (!ready) return null;
 
   const handleClick = async () => {
     setCapturing(true);

--- a/packages/sdk-nextjs/src/warn-toast.ts
+++ b/packages/sdk-nextjs/src/warn-toast.ts
@@ -1,0 +1,143 @@
+const TOAST_ID = "glitchgrab-misconfig-toast";
+const STYLE_ID = "glitchgrab-misconfig-style";
+const ANIMATION_MS = 180;
+const AUTO_DISMISS_MS = 6000;
+
+const seenWarnings = new Set<string>();
+
+function injectStyles() {
+  if (typeof document === "undefined") return;
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = `
+    @keyframes glitchgrab-toast-in {
+      from { transform: translateY(16px); opacity: 0; }
+      to { transform: translateY(0); opacity: 1; }
+    }
+    @keyframes glitchgrab-toast-out {
+      from { transform: translateY(0); opacity: 1; }
+      to { transform: translateY(16px); opacity: 0; }
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+function renderToast(message: string) {
+  if (typeof document === "undefined") return;
+  injectStyles();
+
+  const existing = document.getElementById(TOAST_ID);
+  if (existing) existing.remove();
+
+  const toast = document.createElement("div");
+  toast.id = TOAST_ID;
+  toast.setAttribute("role", "status");
+  toast.setAttribute("aria-live", "polite");
+  toast.style.cssText = [
+    "position:fixed",
+    "bottom:20px",
+    "right:20px",
+    "z-index:2147483647",
+    "max-width:360px",
+    "padding:12px 14px",
+    "border-radius:10px",
+    "background:#18181b",
+    "color:#fafafa",
+    "font-size:13px",
+    "line-height:1.4",
+    'font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+    "box-shadow:0 8px 24px rgba(0,0,0,0.18), 0 2px 6px rgba(0,0,0,0.12)",
+    "display:flex",
+    "align-items:flex-start",
+    "gap:10px",
+    `animation: glitchgrab-toast-in ${ANIMATION_MS}ms ease-out`,
+  ].join(";");
+
+  const icon = document.createElement("span");
+  icon.textContent = "!";
+  icon.style.cssText = [
+    "flex-shrink:0",
+    "width:20px",
+    "height:20px",
+    "border-radius:50%",
+    "background:#f59e0b",
+    "color:#18181b",
+    "font-weight:700",
+    "display:flex",
+    "align-items:center",
+    "justify-content:center",
+    "font-size:13px",
+  ].join(";");
+
+  const body = document.createElement("div");
+  body.style.cssText = "flex:1;min-width:0";
+
+  const title = document.createElement("div");
+  title.textContent = "Glitchgrab not configured";
+  title.style.cssText = "font-weight:600;margin-bottom:2px";
+
+  const detail = document.createElement("div");
+  detail.textContent = message;
+  detail.style.cssText = "color:#d4d4d8;font-size:12px";
+
+  body.appendChild(title);
+  body.appendChild(detail);
+
+  const close = document.createElement("button");
+  close.type = "button";
+  close.setAttribute("aria-label", "Dismiss");
+  close.textContent = "×";
+  close.style.cssText = [
+    "flex-shrink:0",
+    "background:transparent",
+    "border:none",
+    "color:#a1a1aa",
+    "font-size:18px",
+    "line-height:1",
+    "cursor:pointer",
+    "padding:0 2px",
+  ].join(";");
+
+  let dismissTimer: ReturnType<typeof setTimeout> | null = null;
+  const dismiss = () => {
+    if (dismissTimer) clearTimeout(dismissTimer);
+    toast.style.animation = `glitchgrab-toast-out ${ANIMATION_MS}ms ease-in forwards`;
+    setTimeout(() => toast.remove(), ANIMATION_MS);
+  };
+
+  close.addEventListener("click", dismiss);
+  dismissTimer = setTimeout(dismiss, AUTO_DISMISS_MS);
+
+  toast.appendChild(icon);
+  toast.appendChild(body);
+  toast.appendChild(close);
+
+  document.body.appendChild(toast);
+}
+
+/**
+ * Warn once per unique key. Shows a visible toast in the browser
+ * and logs to console. Safe to call repeatedly — will dedupe.
+ */
+export function warnMisconfigured(key: string, message: string) {
+  try {
+    if (!seenWarnings.has(key)) {
+      seenWarnings.add(key);
+      // eslint-disable-next-line no-console
+      console.warn(`[glitchgrab] ${message}`);
+    }
+    renderToast(message);
+  } catch {
+    // never crash the host app
+  }
+}
+
+/** Reset internal state — used by tests. */
+export function __resetWarnToast() {
+  seenWarnings.clear();
+  if (typeof document !== "undefined") {
+    document.getElementById(TOAST_ID)?.remove();
+    document.getElementById(STYLE_ID)?.remove();
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes silent failure when `openReportDialog()` is called without a token — now shows a toast + `console.warn`.
- `useGlitchgrab()` no longer throws when the provider is missing or has no token — returns stub methods instead, so host apps can drop their try/catch safe-hook wrappers.
- Exports new `isGlitchgrabReady()` helper so consumers can conditionally hide trigger buttons.

Closes #146.

## Changes
```
 packages/sdk-nextjs/README.md                      |  21 +++
 .../src/__tests__/misconfigured.test.tsx           | 124 ++++++++++++++++++
 packages/sdk-nextjs/src/index.ts                   |   2 +-
 packages/sdk-nextjs/src/provider.tsx               | 107 ++++++++++-----
 packages/sdk-nextjs/src/report-button.tsx          |  16 +--
 packages/sdk-nextjs/src/warn-toast.ts              | 143 +++++++++++++++++++++
 6 files changed, 370 insertions(+), 43 deletions(-)
```

## CI Pre-check
| Check | Status |
|-------|--------|
| SDK build | ✅ passed |
| SDK tests (33) | ✅ passed |
| lint | ✅ passed |
| typecheck | ✅ passed |
| knip | ✅ passed |
| pruny | ✅ passed |
| web build | ⏭️ skipped (SDK-only change) |

## Test plan
- [ ] Install updated SDK in a consumer app and render `<GlitchgrabProvider token="">`
- [ ] Verify `useGlitchgrab()` no longer throws in dev tools
- [ ] Click a button wired to `openReportDialog()` → toast appears + `console.warn` logs
- [ ] Verify `isGlitchgrabReady()` returns `false` without token, `true` with token
- [ ] Verify `<ReportButton>` hides itself when token is missing
- [ ] Set a real token and confirm normal flow still works (dialog opens, report submits)