### PR TITLE
fix(repos): per-user repo uniqueness + GitHub avatars in connect dialog

### DIFF
--- a/apps/web/app/api/v1/repos/github/route.ts
+++ b/apps/web/app/api/v1/repos/github/route.ts
@@ -8,7 +8,7 @@ interface GitHubRepo {
   id: number;
   full_name: string;
   name: string;
-  owner: { login: string; type: "User" | "Organization" };
+  owner: { login: string; type: "User" | "Organization"; avatar_url: string };
   private: boolean;
   description: string | null;
 }
@@ -71,21 +71,28 @@ export async function GET() {
     name: repo.name,
     owner: repo.owner.login,
     ownerType: repo.owner.type === "Organization" ? "org" : "user",
+    ownerAvatarUrl: repo.owner.avatar_url,
     isPrivate: repo.private,
     description: repo.description,
   }));
 
-  const accountsMap = new Map<string, "user" | "org">();
+  const accountsMap = new Map<string, { type: "user" | "org"; avatarUrl: string }>();
   for (const repo of repos) {
     if (!accountsMap.has(repo.owner)) {
-      accountsMap.set(repo.owner, repo.ownerType as "user" | "org");
+      accountsMap.set(repo.owner, {
+        type: repo.ownerType as "user" | "org",
+        avatarUrl: repo.ownerAvatarUrl,
+      });
     }
   }
-  const accounts = Array.from(accountsMap, ([login, type]) => ({ login, type }))
-    .sort((a, b) => {
-      if (a.type !== b.type) return a.type === "user" ? -1 : 1;
-      return a.login.localeCompare(b.login);
-    });
+  const accounts = Array.from(accountsMap, ([login, meta]) => ({
+    login,
+    type: meta.type,
+    avatarUrl: meta.avatarUrl,
+  })).sort((a, b) => {
+    if (a.type !== b.type) return a.type === "user" ? -1 : 1;
+    return a.login.localeCompare(b.login);
+  });
 
   const clientId = process.env.GITHUB_CLIENT_ID;
   const connectionUrl = clientId

--- a/apps/web/app/dashboard/repos/actions.ts
+++ b/apps/web/app/dashboard/repos/actions.ts
@@ -107,19 +107,19 @@ export async function connectRepo(
   owner: string,
   name: string,
   isPrivate: boolean
-) {
+): Promise<{ ok: true } | { ok: false; error: string }> {
   const session = await auth();
 
   if (!session?.user?.id) {
-    throw new Error("Unauthorized");
+    return { ok: false, error: "Unauthorized" };
   }
 
   const existing = await prisma.repo.findUnique({
-    where: { githubId },
+    where: { userId_githubId: { userId: session.user.id, githubId } },
   });
 
   if (existing) {
-    throw new Error("Repo already connected");
+    return { ok: false, error: "Repo already connected" };
   }
 
   await prisma.repo.create({
@@ -139,6 +139,8 @@ export async function connectRepo(
   );
 
   revalidatePath("/dashboard/repos");
+
+  return { ok: true };
 }
 
 async function setupGitHubWebhook(userId: string, owner: string, repo: string) {

--- a/apps/web/app/dashboard/repos/connect-repo-dialog.tsx
+++ b/apps/web/app/dashboard/repos/connect-repo-dialog.tsx
@@ -23,6 +23,7 @@ interface GitHubRepo {
   name: string;
   owner: string;
   ownerType: "user" | "org";
+  ownerAvatarUrl: string;
   isPrivate: boolean;
   description: string | null;
 }
@@ -30,6 +31,7 @@ interface GitHubRepo {
 interface GitHubAccount {
   login: string;
   type: "user" | "org";
+  avatarUrl: string;
 }
 
 interface GitHubReposResponse {
@@ -72,13 +74,14 @@ export function ConnectRepoDialog() {
 
   const { mutate, isPending, variables } = useMutation({
     mutationFn: async (repo: GitHubRepo) => {
-      await connectRepo(
+      const result = await connectRepo(
         repo.githubId,
         repo.fullName,
         repo.owner,
         repo.name,
         repo.isPrivate
       );
+      if (!result.ok) throw new Error(result.error);
       return repo;
     },
     onSuccess: (repo) => {
@@ -89,6 +92,7 @@ export function ConnectRepoDialog() {
     },
     onError: (err) => {
       toast.error(err instanceof Error ? err.message : "Failed to connect repo");
+      queryClient.invalidateQueries({ queryKey: ["repos"] });
     },
   });
 
@@ -193,7 +197,17 @@ export function ConnectRepoDialog() {
                       : "bg-card border-border text-muted-foreground hover:text-foreground"
                   }`}
                 >
-                  <Building2 className="h-3 w-3" />
+                  {acc.avatarUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={acc.avatarUrl}
+                      alt={acc.login}
+                      loading="lazy"
+                      className="h-3.5 w-3.5 rounded-sm object-cover"
+                    />
+                  ) : (
+                    <Building2 className="h-3 w-3" />
+                  )}
                   {acc.login}
                 </button>
               );
@@ -276,8 +290,20 @@ export function ConnectRepoDialog() {
                       isConnected ? "bg-border" : "bg-primary/70"
                     }`}
                   />
-                  <div className="w-8 h-8 rounded border border-border bg-card flex items-center justify-center text-muted-foreground shrink-0 ml-1">
-                    <Github className="h-4 w-4" />
+                  <div className="w-8 h-8 rounded border border-border bg-card overflow-hidden shrink-0 ml-1">
+                    {repo.ownerAvatarUrl ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={repo.ownerAvatarUrl}
+                        alt={repo.owner}
+                        loading="lazy"
+                        className="w-full h-full object-cover"
+                      />
+                    ) : (
+                      <div className="w-full h-full flex items-center justify-center text-muted-foreground">
+                        <Github className="h-4 w-4" />
+                      </div>
+                    )}
                   </div>
                   <div className="min-w-0">
                     <div className="flex items-center gap-2 flex-wrap">

--- a/apps/web/prisma/migrations/20260421_repo_user_github_unique/migration.sql
+++ b/apps/web/prisma/migrations/20260421_repo_user_github_unique/migration.sql
@@ -1,0 +1,11 @@
+-- Scope Repo.githubId uniqueness per user so multiple users can connect the same GitHub repo.
+-- Previous constraint: Repo.githubId globally unique (one user could block all others).
+
+-- DropIndex
+DROP INDEX "Repo_githubId_key";
+
+-- CreateIndex
+CREATE INDEX "Repo_githubId_idx" ON "Repo"("githubId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Repo_userId_githubId_key" ON "Repo"("userId", "githubId");

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -81,7 +81,7 @@ model VerificationToken {
 model Repo {
   id        String   @id @default(cuid())
   userId    String
-  githubId  Int      @unique
+  githubId  Int
   fullName  String
   owner     String
   name      String
@@ -93,6 +93,9 @@ model Repo {
   reports           Report[]
   issues            Issue[]
   collaboratorRepos CollaboratorRepo[]
+
+  @@unique([userId, githubId])
+  @@index([githubId])
 }
 
 model ApiToken {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "packageManager": "bun@1.3.7",
   "private": true,
   "scripts": {
-    "dev": "dotenvx run -- turbo dev",
+    "dev": "dotenvx run -- turbo dev --filter=!@glitchgrab/mobile",
     "dev:web": "dotenvx run -- turbo dev --filter=@glitchgrab/web",
     "dev:mobile": "cd apps/mobile && expo start",
     "build": "dotenvx run -- turbo build --filter=@glitchgrab/web",


### PR DESCRIPTION
## Summary
- **Fix "Repo already connected" crash** — `Repo.githubId` was globally `@unique`, so whichever user connected a repo first blocked every other user (including the GitHub owner). Switched to composite `@@unique([userId, githubId])` + non-unique index on `githubId`. Multiple users can now each connect the same GitHub repo independently.
- **Stop page error-boundary crash on duplicate connect** — `connectRepo` server action now returns `{ ok, error? }` instead of throwing. Throwing bubbled to Next 15's page error boundary, producing the generic "Server Components render" toast + 500 RSC response. Client re-throws inside `useMutation` so the existing `onError` toast still fires, and invalidates `repos` so stale CONNECT buttons refresh.
- **GitHub owner avatars in connect dialog** — `/api/v1/repos/github` now surfaces `owner.avatar_url` per repo and per account. Dialog renders real avatars in repo rows and org filter chips (plain `<img>`, no `next.config` host allowlist needed). Falls back to generic icon when missing.
- **Exclude mobile from `bun dev`** — `turbo dev --filter=!@glitchgrab/mobile`. `bun run dev:mobile` still starts Expo explicitly.

## Changes
\`\`\`
 apps/web/app/api/v1/repos/github/route.ts          | 23 ++++++++++-----
 apps/web/app/dashboard/repos/actions.ts            | 10 ++++---
 .../app/dashboard/repos/connect-repo-dialog.tsx    | 34 +++++++++++++++++++---
 .../20260421_repo_user_github_unique/migration.sql | 11 +++++++
 apps/web/prisma/schema.prisma                      |  5 +++-
 package.json                                       |  2 +-
 6 files changed, 67 insertions(+), 18 deletions(-)
\`\`\`

## Migration
New migration `20260421_repo_user_github_unique`:
- `DROP INDEX "Repo_githubId_key"`
- `CREATE INDEX "Repo_githubId_idx"`
- `CREATE UNIQUE INDEX "Repo_userId_githubId_key"`

Safe: existing rows are one per `githubId` (global unique enforced), so composite constraint cannot collide.

## CI Pre-check
| Check | Status |
|-------|--------|
| lint (turbo) | ✅ passed |
| typecheck / knip / pruny / build | ⏭️ deferred to CI (project convention skips local \`bun run validate\`) |

## Test plan
- [ ] Open Connect Repo dialog — owner avatars render per row and per org chip
- [ ] Click Connect on a repo already owned by another Glitchgrab user — toast "Repo already connected", no page crash, no 500 in Network tab
- [ ] Click Connect on a repo none of your users has — connects, toast success, row flips to CONNECTED
- [ ] Verify dashboard Repos page still loads after the CI migration deploys on prod/staging