### PR TITLE
fix(ci,tokens): caller perms + env-var copy option in token dialog

### DIFF
--- a/.github/workflows/claude-auto-fix.yml
+++ b/.github/workflows/claude-auto-fix.yml
@@ -6,5 +6,11 @@ on:
 
 jobs:
   auto-fix:
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
     uses: Navibyte-Innovations-Pvt-Ltd/.github/.github/workflows/claude-auto-fix-reusable.yml@main
     secrets: inherit

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,5 +12,11 @@ on:
 
 jobs:
   claude:
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
     uses: Navibyte-Innovations-Pvt-Ltd/.github/.github/workflows/claude-reusable.yml@main
     secrets: inherit

--- a/apps/web/app/dashboard/tokens/create-token-dialog.tsx
+++ b/apps/web/app/dashboard/tokens/create-token-dialog.tsx
@@ -40,8 +40,12 @@ export function CreateTokenDialog({ repos }: { repos: Repo[] }) {
   const [repoName, setRepoName] = useState(repos[0]?.fullName ?? "");
   const [name, setName] = useState("");
   const [generatedToken, setGeneratedToken] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
+  const [copied, setCopied] = useState<"token" | "env" | null>(null);
   const [pending, startTransition] = useTransition();
+
+  const envLine = generatedToken
+    ? `NEXT_PUBLIC_GLITCHGRAB_TOKEN=${generatedToken}`
+    : "";
 
   const selectedRepoId = repos.find((r) => r.fullName === repoName)?.id ?? "";
 
@@ -62,12 +66,13 @@ export function CreateTokenDialog({ repos }: { repos: Repo[] }) {
     });
   }
 
-  async function handleCopy() {
+  async function handleCopy(kind: "token" | "env") {
     if (!generatedToken) return;
-    await copyToClipboard(generatedToken);
-    setCopied(true);
-    toast.success("Copied to clipboard");
-    setTimeout(() => setCopied(false), 2000);
+    const value = kind === "env" ? envLine : generatedToken;
+    await copyToClipboard(value);
+    setCopied(kind);
+    toast.success(kind === "env" ? "Copied .env line" : "Copied token");
+    setTimeout(() => setCopied(null), 2000);
   }
 
   function handleClose(isOpen: boolean) {
@@ -75,7 +80,7 @@ export function CreateTokenDialog({ repos }: { repos: Repo[] }) {
     if (!isOpen) {
       setGeneratedToken(null);
       setName("");
-      setCopied(false);
+      setCopied(null);
     }
   }
 
@@ -110,29 +115,58 @@ export function CreateTokenDialog({ repos }: { repos: Repo[] }) {
 
         {generatedToken ? (
           <div className="space-y-4">
-            <div className="flex items-center gap-2">
-              <code className="flex-1 rounded border border-border bg-card px-3 py-2 text-xs font-mono break-all text-foreground">
-                {generatedToken}
-              </code>
-              <Button
-                variant="outline"
-                size="icon"
-                onClick={handleCopy}
-                aria-label="Copy token"
-              >
-                {copied ? (
-                  <Check className="h-4 w-4 text-primary" />
-                ) : (
-                  <Copy className="h-4 w-4" />
-                )}
-              </Button>
+            <div>
+              <p className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground mb-1.5">
+                token
+              </p>
+              <div className="flex items-center gap-2">
+                <code className="flex-1 rounded border border-border bg-card px-3 py-2 text-xs font-mono break-all text-foreground">
+                  {generatedToken}
+                </code>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  onClick={() => handleCopy("token")}
+                  aria-label="Copy token"
+                >
+                  {copied === "token" ? (
+                    <Check className="h-4 w-4 text-primary" />
+                  ) : (
+                    <Copy className="h-4 w-4" />
+                  )}
+                </Button>
+              </div>
             </div>
+
+            <div>
+              <p className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground mb-1.5">
+                .env line
+              </p>
+              <div className="flex items-center gap-2">
+                <code className="flex-1 rounded border border-border bg-card px-3 py-2 text-xs font-mono break-all text-foreground">
+                  {envLine}
+                </code>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  onClick={() => handleCopy("env")}
+                  aria-label="Copy as .env line"
+                >
+                  {copied === "env" ? (
+                    <Check className="h-4 w-4 text-primary" />
+                  ) : (
+                    <Copy className="h-4 w-4" />
+                  )}
+                </Button>
+              </div>
+            </div>
+
             <div className="rounded border border-primary/30 bg-primary/5 p-3">
               <p className="font-mono text-[10px] uppercase tracking-widest text-primary/80 mb-2">
                 usage · next.js
               </p>
               <code className="text-[11px] font-mono text-foreground block break-all">
-                {`<GlitchgrabProvider token="${generatedToken}">`}
+                {`<GlitchgrabProvider token={process.env.NEXT_PUBLIC_GLITCHGRAB_TOKEN}>`}
               </code>
             </div>
             <Button

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "pruny:fix": "pruny --fix",
     "db:generate": "cd apps/web && dotenvx run -f ../../.env -- ./node_modules/.bin/prisma generate",
     "db:push": "cd apps/web && dotenvx run -f ../../.env -- ./node_modules/.bin/prisma db push",
+    "db:deploy": "cd apps/web && dotenvx run -f ../../.env -- ./node_modules/.bin/prisma migrate deploy",
     "db:migrate": "cd apps/web && dotenvx run -f ../../.env -- ./node_modules/.bin/prisma migrate dev",
     "db:studio": "cd apps/web && dotenvx run -f ../../.env -- ./node_modules/.bin/prisma studio",
     "db:reset": "cd apps/web && dotenvx run -f ../../.env -- ./node_modules/.bin/prisma migrate reset --force",


### PR DESCRIPTION
## Summary
- **Fix Claude Auto-Fix + Claude Code workflows startup failure** — Caller stubs (`.github/workflows/claude-auto-fix.yml`, `.github/workflows/claude.yml`) previously had no `permissions:` block. Repo default is `read`, but the central reusable workflows in `Navibyte-Innovations-Pvt-Ltd/.github` need `contents/issues/pull-requests/id-token: write`. GitHub rule: caller job can only restrict (not expand) permissions granted to the reusable, so missing block → startup failure. Added matching `permissions:` block in each caller stub.
- **Two-copy option in token-generated dialog** — Separate "token" and ".env line" rows, each with its own copy button. `.env` line emits `NEXT_PUBLIC_GLITCHGRAB_TOKEN=<token>` so devs can paste straight into a local env file. Next.js usage hint updated to `<GlitchgrabProvider token={process.env.NEXT_PUBLIC_GLITCHGRAB_TOKEN}>`.
- **`db:deploy` root script** — `prisma migrate deploy` wired from repo root so prod deploys can run committed migrations (e.g. the new `20260421_repo_user_github_unique` migration shipped in #152).

## Changes
\`\`\`
 .github/workflows/claude-auto-fix.yml              |  6 ++
 .github/workflows/claude.yml                       |  6 ++
 .../app/dashboard/tokens/create-token-dialog.tsx   | 82 +++++++++++++++-------
 package.json                                       |  1 +
 4 files changed, 71 insertions(+), 24 deletions(-)
\`\`\`

## Follow-up (not in this PR)
Same permissions fix should be applied to the caller templates in `Navibyte-Innovations-Pvt-Ltd/.github/caller-templates/` so \`sync-callers.yml\` doesn't overwrite this patch on next run.

## CI Pre-check
| Check | Status |
|-------|--------|
| lint (turbo) | ✅ passed |
| typecheck / knip / pruny / build | ⏭️ deferred to CI |

## Test plan
- [ ] Open a new GitHub issue → Claude Auto-Fix workflow starts (no "Invalid workflow file" startup failure)
- [ ] Comment \`@claude\` on an issue/PR → Claude Code workflow starts
- [ ] Generate a new API token → dialog shows two copy rows; each button copies the correct string; "copied" check mark shows per-row
- [ ] Run \`bun run db:deploy\` in CI/prod — applies pending migrations without prompting