### PR TITLE
docs: document keyboard shortcuts for report dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,11 +122,11 @@ bun run dev
 - [x] GitHub OAuth + repo connection + token generation
 - [x] AI pipeline: image/text → structured GitHub issue
 - [x] SDK: Error boundary + auto-capture
-- [x] SDK: Report Error button
+- [x] SDK: Report Error button + keyboard shortcuts (Cmd+Shift+G, Cmd+V paste)
 - [x] Dashboard: Upload screenshots
 - [x] AI deduplication check
+- [x] Mobile app (Android + iOS)
 - [ ] MCP server
-- [ ] Mobile app (Android + iOS)
 - [ ] Linear + Jira support
 - [ ] Multi-framework SDK (React, Vue)
 

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -17,6 +17,7 @@ Glitchgrab eliminates the manual work of triaging "it's broken" Slack messages a
 - **Dashboard Chat**: Developers paste screenshots or describe bugs in the Glitchgrab web dashboard. The AI pipeline normalizes, enriches, deduplicates, and generates a structured issue.
 - **AI Deduplication**: Before creating an issue, Glitchgrab checks existing open GitHub issues for semantic duplicates. Identical errors spike 100× in production — dedup prevents noise.
 - **Multi-provider AI**: Abstracts over Claude and OpenAI. Users can bring their own API key (BYOK) or use platform-provided keys.
+- **Keyboard Shortcuts**: `Cmd+Shift+G` (Mac) / `Ctrl+Shift+G` (Windows/Linux) opens the report dialog from anywhere. `Cmd+V` / `Ctrl+V` pastes a screenshot from the clipboard when the dialog is open.
 - **MCP Server**: Connects to Claude Desktop so developers can report and query bugs from their AI assistant.
 - **Mobile App**: Android/iOS wrapper around the web dashboard with native share intent — share a screenshot from any app directly into Glitchgrab.
 

--- a/packages/sdk-nextjs/README.md
+++ b/packages/sdk-nextjs/README.md
@@ -146,6 +146,18 @@ function FeedbackWidget() {
 
 Note: `openReportDialog()` requires a `<ReportButton>` to be mounted somewhere in the component tree. It triggers the same modal with screenshot capture.
 
+## Keyboard Shortcuts
+
+Once `GlitchgrabProvider` is mounted, these shortcuts work globally:
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd+Shift+G` / `Ctrl+Shift+G` | Open the report dialog |
+| `Cmd+V` / `Ctrl+V` (dialog open) | Paste a screenshot from clipboard |
+| `Escape` | Close the dialog |
+
+No configuration needed — shortcuts are active as long as the provider is in the tree.
+
 ## Fetching Reports by User
 
 ### React hook (recommended)


### PR DESCRIPTION
## Summary
- Add keyboard shortcuts section to SDK README with shortcut reference table
- Add keyboard shortcuts to llms.txt key features for AI crawler indexing
- Mark mobile app as shipped and note keyboard shortcuts in root README roadmap

Closes #162

## Changes
 README.md                     |  4 ++--
 apps/web/public/llms.txt      |  1 +
 packages/sdk-nextjs/README.md | 12 ++++++++++++
 3 files changed, 15 insertions(+), 2 deletions(-)

## CI Pre-check
| Check | Status |
|-------|--------|
| CI | ⏭️ skipped — all changed files match `paths-ignore` (**.md, public/**) |

## Test plan
- [ ] Verify `Cmd+Shift+G` opens report dialog on a host Next.js app
- [ ] Verify `Cmd+V` pastes clipboard image when dialog is open
- [ ] Verify `Escape` closes the dialog

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Navibyte-Innovations-Pvt-Ltd/codesmith/glitchgrab/pr/164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->