### PR TITLE
fix(sdk): use waitUntil to prevent PROCESSING reports on Vercel

### DIFF
--- a/apps/scripts/db-sync.ts
+++ b/apps/scripts/db-sync.ts
@@ -1,11 +1,36 @@
 import { execSync } from 'child_process';
+import path from 'path';
+import fs from 'fs';
+import dotenv from 'dotenv';
 
+/**
+ * Database connection parts
+ */
 interface DbConnectionParts {
     host: string;
     port: string;
     user: string;
     password: string;
     database: string;
+}
+
+// Load environment variables from .env file
+// Try to find .env in workspace root
+const findEnvFile = (dir: string): string | null => {
+    const envPath = path.join(dir, '.env');
+    if (fs.existsSync(envPath)) {
+        return envPath;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+        return null;
+    }
+    return findEnvFile(parent);
+};
+
+const envFile = findEnvFile(process.cwd());
+if (envFile) {
+    dotenv.config({ path: envFile });
 }
 
 /**
@@ -23,7 +48,7 @@ const colors = {
 
 const validateEnv = (): { localDbUrl: string; prodDbUrl: string } => {
     const localDbUrl = process.env.NEXT_DIRECT_URL;
-    const prodDbUrl = process.env.PROD_NEXT_POSTGRES_URL;
+    const prodDbUrl = process.env.PROD_DATABASE_URL; // eslint-disable-line turbo/no-undeclared-env-vars
 
     if (!localDbUrl) {
         console.error(
@@ -34,16 +59,16 @@ const validateEnv = (): { localDbUrl: string; prodDbUrl: string } => {
 
     if (!prodDbUrl) {
         console.error(
-            `${colors.red}${colors.bold}Error: PROD_NEXT_POSTGRES_URL is not defined in your environment.${colors.reset}`
+            `${colors.red}${colors.bold}Error: PROD_DATABASE_URL is not defined in your environment.${colors.reset}`
         );
         console.warn(
-            `${colors.yellow}Please add PROD_NEXT_POSTGRES_URL to your .env file.${colors.reset}`
+            `${colors.yellow}Please add PROD_DATABASE_URL to your .env file.${colors.reset}`
         );
         process.exit(1);
     }
 
     // Hard stop: destination must never be a cloud/remote database
-    const isRemoteDb = (url: string) =>
+    const isRemoteDb = (url: string): boolean =>
         url.includes('neon.tech') ||
         url.includes('.aws.') ||
         url.includes('supabase') ||
@@ -63,7 +88,7 @@ const validateEnv = (): { localDbUrl: string; prodDbUrl: string } => {
         const localHost = new URL(localDbUrl).hostname;
         const prodHost = new URL(prodDbUrl).hostname;
         if (localHost === prodHost) {
-            console.error(`${colors.red}${colors.bold}ABORTED: NEXT_DIRECT_URL and PROD_NEXT_POSTGRES_URL point to the same host.${colors.reset}`);
+            console.error(`${colors.red}${colors.bold}ABORTED: NEXT_DIRECT_URL and PROD_DATABASE_URL point to the same host.${colors.reset}`);
             console.error(`${colors.red}You are about to overwrite your production database. Refusing to run.${colors.reset}`);
             process.exit(1);
         }

--- a/apps/web/app/api/v1/sdk/report/route.ts
+++ b/apps/web/app/api/v1/sdk/report/route.ts
@@ -1,6 +1,7 @@
 export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
+import { waitUntil } from "@vercel/functions";
 import { prisma } from "@/lib/db";
 import { hashToken } from "@/lib/tokens";
 import { processReport } from "@/lib/pipeline";
@@ -360,9 +361,11 @@ export async function POST(request: Request) {
       );
     }
 
-    // Auto-capture — process async, respond immediately
-    processReport(report.id).catch((err) =>
-      console.error("SDK auto-capture pipeline error:", err)
+    // Auto-capture — register background work before responding so Vercel doesn't kill it
+    waitUntil(
+      processReport(report.id).catch((err) =>
+        console.error("SDK auto-capture pipeline error:", err)
+      )
     );
 
     return NextResponse.json(

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "@aws-sdk/client-s3": "^3.1017.0",
     "@base-ui/react": "^1.3.0",
     "@prisma/client": "6",
+    "@vercel/functions": "^3.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "glitchgrab": "workspace:*",

--- a/bun.lock
+++ b/bun.lock
@@ -60,6 +60,7 @@
         "@aws-sdk/client-s3": "^3.1017.0",
         "@base-ui/react": "^1.3.0",
         "@prisma/client": "6",
+        "@vercel/functions": "^3.5.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "glitchgrab": "workspace:*",
@@ -1333,6 +1334,10 @@
     "@urql/core": ["@urql/core@4.0.11", "", { "dependencies": { "@0no-co/graphql.web": "^1.0.1", "wonka": "^6.3.2" } }, "sha512-FFdY97vF5xnUrElcGw9erOLvtu+KGMLfwrLNDfv4IPgdp2IBsiGe+Kb7Aypfd3kH//BETewVSLm3+y2sSzjX6A=="],
 
     "@urql/exchange-retry": ["@urql/exchange-retry@1.2.0", "", { "dependencies": { "@urql/core": ">=4.0.0", "wonka": "^6.3.2" } }, "sha512-1O/biKiVhhn0EtvDF4UOvz325K4RrLupfL8rHcmqD2TBLv4qVDWQuzx4JGa1FfqjjRb+C9TNZ6w19f32Mq85Ug=="],
+
+    "@vercel/functions": ["@vercel/functions@3.5.0", "", { "dependencies": { "@vercel/oidc": "3.4.0" }, "peerDependencies": { "@aws-sdk/credential-provider-web-identity": "*" }, "optionalPeers": ["@aws-sdk/credential-provider-web-identity"] }, "sha512-+RokZ+4gkYyOsKBuJ29cQ8iSZG123LLJbZfPry20kkTgrN9U0277La4feP4DnWVo3sGoYa4plCEKY9XKUYoX9g=="],
+
+    "@vercel/oidc": ["@vercel/oidc@3.4.0", "", {}, "sha512-p0sKfHkfRmMaqqDwNL4tjnX9TgRrLMlEtUjIxfrEns8pOxz1R9ztqOVI+ehqiq93/2/HnfPe/UBZkfAZwnx0UA=="],
 
     "@vitest/expect": ["@vitest/expect@4.1.3", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.3", "@vitest/utils": "4.1.3", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-CW8Q9KMtXDGHj0vCsqui0M5KqRsu0zm0GNDW7Gd3U7nZ2RFpPKSCpeCXoT+/+5zr1TNlsoQRDEz+LzZUyq6gnQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@tanstack/react-query": "^5.95.2",
         "axios": "^1.13.6",
+        "dotenv": "^17.4.2",
         "next-sitemap": "^4.2.3",
       },
       "devDependencies": {
@@ -96,7 +97,7 @@
     },
     "packages/sdk-nextjs": {
       "name": "glitchgrab",
-      "version": "1.14.1",
+      "version": "1.17.1",
       "dependencies": {
         "html2canvas-pro": "^2.0.2",
       },
@@ -1719,7 +1720,7 @@
 
     "dot-prop": ["dot-prop@5.3.0", "", { "dependencies": { "is-obj": "^2.0.0" } }, "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q=="],
 
-    "dotenv": ["dotenv@17.3.1", "", {}, "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA=="],
+    "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
 
     "dotenv-expand": ["dotenv-expand@11.0.7", "", { "dependencies": { "dotenv": "^16.4.5" } }, "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA=="],
 
@@ -3404,6 +3405,8 @@
     "@babel/traverse--for-generate-function-map/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+
+    "@dotenvx/dotenvx/dotenv": ["dotenv@17.3.1", "", {}, "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA=="],
 
     "@emnapi/core/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@tanstack/react-query": "^5.95.2",
     "axios": "^1.13.6",
+    "dotenv": "^17.4.2",
     "next-sitemap": "^4.2.3"
   }
 }


### PR DESCRIPTION
## Summary
- Fix SDK auto-capture reports stuck in PROCESSING status — pipeline was fire-and-forget, Vercel killed the serverless function after response before pipeline could complete
- Wrap `processReport()` in `waitUntil()` from `@vercel/functions` so Vercel keeps the function alive until the AI pipeline finishes
- Add `@vercel/functions` dependency to web app

## Changes
 apps/scripts/db-sync.ts                 | 35 ++++++++++++++++++++++++++++-----
 apps/web/app/api/v1/sdk/report/route.ts |  9 ++++++---
 apps/web/package.json                   |  1 +
 bun.lock                                | 12 +++++++++--
 package.json                            |  1 +
 5 files changed, 48 insertions(+), 10 deletions(-)}

## CI Pre-check
| Check | Status |
|-------|--------|
| lint | ✅ passed |
| typecheck | ✅ passed |
| SDK tests | ✅ passed (37/37) |
| knip | ✅ passed |
| pruny | ✅ passed |

## Test plan
- [ ] Submit an auto-capture SDK report from a production app
- [ ] Verify report transitions from PROCESSING → CREATED
- [ ] Verify GitHub issue is created on the connected repo
- [ ] Existing PROCESSING-stuck reports need manual SQL reset to FAILED

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Navibyte-Innovations-Pvt-Ltd/codesmith/glitchgrab/pr/167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->