### PR TITLE
fix: include session/user info in auto-captured SDK bug reports

### DIFF
--- a/apps/web/lib/pipeline.ts
+++ b/apps/web/lib/pipeline.ts
@@ -150,14 +150,25 @@ export async function processReport(
           issueBody += `\n\n## Screenshot${refs.length > 1 ? "s" : ""}\n\n${refs.join("\n\n")}`;
         }
       }
-      // Add collaborator attribution if applicable
+      // Add reporter / collaborator attribution
       const collabEmail = report.metadata && typeof report.metadata === "object"
         ? (report.metadata as Record<string, unknown>).collaboratorEmail
         : null;
+
       if (collabEmail) {
         issueBody += `\n\n---\n> Reported by: ${collabEmail}\n\n*Reported via [Glitchgrab](https://glitchgrab.dev)*`;
       } else {
-        issueBody += "\n\n---\n*Reported via [Glitchgrab](https://glitchgrab.dev)*";
+        const reporterParts: string[] = [];
+        if (report.reporterName && report.reporterName !== "Unknown") reporterParts.push(report.reporterName);
+        if (report.reporterEmail) reporterParts.push(`(${report.reporterEmail})`);
+        if (report.reporterPhone) reporterParts.push(`📞 ${report.reporterPhone}`);
+        if (report.reporterPrimaryKey && report.reporterPrimaryKey !== "unknown") reporterParts.push(`• ID: \`${report.reporterPrimaryKey}\``);
+
+        if (reporterParts.length > 0) {
+          issueBody += `\n\n---\n> **Reported by:** ${reporterParts.join(" ")}\n\n*Reported via [Glitchgrab](https://glitchgrab.dev)*`;
+        } else {
+          issueBody += "\n\n---\n*Reported via [Glitchgrab](https://glitchgrab.dev)*";
+        }
       }
 
       const createdIssue = await createGitHubIssue(account.access_token, {

--- a/packages/sdk-nextjs/src/global.d.ts
+++ b/packages/sdk-nextjs/src/global.d.ts
@@ -1,0 +1,1 @@
+declare const process: { env: { NODE_ENV: string } };

--- a/packages/sdk-nextjs/src/provider.tsx
+++ b/packages/sdk-nextjs/src/provider.tsx
@@ -156,6 +156,7 @@ function GlitchgrabProviderInner({
               ...(session?.userId ? { sessionUserId: session.userId } : {}),
               ...(session?.name ? { sessionUserName: String(session.name) } : {}),
               ...(session?.email ? { sessionUserEmail: String(session.email) } : {}),
+              ...(session?.phone ? { sessionUserPhone: String(session.phone) } : {}),
             },
           };
           sendReport(payload, baseUrl).then((result) => {
@@ -196,6 +197,7 @@ function GlitchgrabProviderInner({
               ...(session?.userId ? { sessionUserId: session.userId } : {}),
               ...(session?.name ? { sessionUserName: String(session.name) } : {}),
               ...(session?.email ? { sessionUserEmail: String(session.email) } : {}),
+              ...(session?.phone ? { sessionUserPhone: String(session.phone) } : {}),
             },
           };
           sendReport(payload, baseUrl).then((result) => {
@@ -217,7 +219,7 @@ function GlitchgrabProviderInner({
     } catch {
       // Never crash
     }
-  }, [token, baseUrl, onError, onReportSent]);
+  }, [token, baseUrl, onError, onReportSent, session]);
 
   const report = useCallback(
     async (


### PR DESCRIPTION
## Summary
- Auto-captured errors (`SDK_AUTO`) were missing session/user context in generated GitHub issues because the pipeline only checked for collaborator email, ignoring `reporterName/Email/Phone/PrimaryKey` fields already saved to the DB
- `session` was missing from the `useEffect` dependency array in the SDK provider, causing event handlers to close over a stale `null` session when users authenticate after component mount
- `sessionUserPhone` was omitted from auto-capture payloads (`handleError` / `handleRejection`) despite being included in user-initiated reports

## Changes
 apps/web/lib/pipeline.ts             | 15 +++++++++++++--
 packages/sdk-nextjs/src/global.d.ts  |  1 +
 packages/sdk-nextjs/src/provider.tsx |  4 +++-
 3 files changed, 17 insertions(+), 3 deletions(-)

## CI Pre-check
| Check | Status |
|-------|--------|
| lint | ✅ passed |
| typecheck | ✅ passed |
| knip | ✅ passed |
| pruny | ✅ passed |
| build | ✅ passed |

## Test plan
- [ ] Trigger an unhandled error in a host app with `GlitchgrabProvider` session set — verify generated GitHub issue includes reporter name, email, phone, and ID
- [ ] Trigger error before session is set, then set session and trigger another — verify second issue includes session info (deps fix)
- [ ] Verify `SDK_USER_REPORT` flow unchanged
- [ ] Closes #169

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Navibyte-Innovations-Pvt-Ltd/codesmith/glitchgrab/pr/170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->