### PR TITLE
fix(sdk): include session data in error boundary auto-reports

### DIFF
--- a/packages/sdk-nextjs/src/error-boundary.tsx
+++ b/packages/sdk-nextjs/src/error-boundary.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import * as React from "react";
-import type { ReportPayload } from "./types";
+import type { GlitchgrabSession, ReportPayload } from "./types";
 import { captureContext, sendReport } from "./utils";
 import { computeSignature, shouldSkipDuplicate } from "./dedup";
 
 interface ErrorBoundaryProps {
   token: string;
   baseUrl?: string;
+  session?: GlitchgrabSession | null;
   onError?: (error: Error) => void;
   fallback?: React.ReactNode;
   visitedPages: string[];
@@ -45,6 +46,7 @@ export class GlitchgrabErrorBoundary extends React.Component<
         return;
       }
 
+      const session = this.props.session;
       const payload: ReportPayload = {
         token: this.props.token,
         source: "SDK_AUTO",
@@ -59,6 +61,10 @@ export class GlitchgrabErrorBoundary extends React.Component<
         metadata: {
           timestamp: context.timestamp,
           visitedPages: JSON.stringify(context.visitedPages),
+          ...(session?.userId ? { sessionUserId: session.userId } : {}),
+          ...(session?.name ? { sessionUserName: String(session.name) } : {}),
+          ...(session?.email ? { sessionUserEmail: String(session.email) } : {}),
+          ...(session?.phone ? { sessionUserPhone: String(session.phone) } : {}),
         },
       };
 

--- a/packages/sdk-nextjs/src/provider.tsx
+++ b/packages/sdk-nextjs/src/provider.tsx
@@ -308,6 +308,7 @@ function GlitchgrabProviderInner({
       <GlitchgrabErrorBoundary
         token={token}
         baseUrl={baseUrl}
+        session={session}
         onError={onError}
         fallback={fallback}
         visitedPages={visitedPagesRef.current}


### PR DESCRIPTION
## Summary

- `GlitchgrabErrorBoundary` was missing a `session` prop, so `componentDidCatch` sent reports with no user identity
- Added `session?: GlitchgrabSession | null` to `ErrorBoundaryProps` and populated `sessionUserId`, `sessionUserName`, `sessionUserEmail`, `sessionUserPhone` in the metadata — matching exactly how the `window.onerror` / `unhandledrejection` handlers do it
- `GlitchgrabProviderInner` now passes `session={session}` to `<GlitchgrabErrorBoundary>` so the prop is wired end-to-end

## Root cause

`componentDidCatch` fires synchronously and stamps the error's dedup signature before `window.onerror` runs. `window.onerror` (which was already session-aware) then sees the same signature in the dedup cache and skips the report entirely. Result: auto-caught React tree errors always produced anonymous reports.

## Test plan

- [ ] Wrap a component that throws inside `GlitchgrabProvider` with a `session` prop
- [ ] Trigger the error — confirm the submitted report's `metadata` includes `sessionUserId` / `sessionUserName`
- [ ] Verify the fix does not break apps that omit `session` (all session fields are optional)
- [ ] `cd packages/sdk-nextjs && bun run build` — passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Navibyte-Innovations-Pvt-Ltd/codesmith/glitchgrab/pr/173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->