### PR TITLE
feat(analytics): day-wise issue closing analytics report

### DIFF
--- a/apps/web/app/api/v1/reports/analytics/issues-closed/route.ts
+++ b/apps/web/app/api/v1/reports/analytics/issues-closed/route.ts
@@ -1,0 +1,141 @@
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/db";
+import { getCollabSession } from "@/lib/collab-auth";
+
+interface GithubIssue {
+  number: number;
+  title: string;
+  html_url: string;
+  closed_at: string | null;
+  pull_request?: unknown;
+}
+
+export async function GET(request: Request) {
+  try {
+    const session = await auth();
+    const collabSession = await getCollabSession();
+    const userId = session?.user?.id;
+
+    if (!userId && !collabSession) {
+      return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const days = Math.min(90, Math.max(7, parseInt(searchParams.get("days") ?? "30", 10)));
+
+    const repoIds: string[] = [];
+    if (userId) {
+      const repos = await prisma.repo.findMany({ where: { userId }, select: { id: true } });
+      repoIds.push(...repos.map((r) => r.id));
+    }
+    if (collabSession) {
+      const collabRepos = await prisma.collaboratorRepo.findMany({
+        where: { collaborator: { id: collabSession.collaboratorId, status: "ACCEPTED" } },
+        select: { repoId: true },
+      });
+      repoIds.push(...collabRepos.map((r) => r.repoId));
+    }
+
+    const today = new Date();
+    today.setUTCHours(23, 59, 59, 999);
+    const startDate = new Date(today);
+    startDate.setUTCDate(startDate.getUTCDate() - (days - 1));
+    startDate.setUTCHours(0, 0, 0, 0);
+
+    const buckets: { date: string; count: number; issues: { number: number; title: string; url: string; repoFullName: string }[] }[] = [];
+    for (let i = 0; i < days; i++) {
+      const d = new Date(startDate);
+      d.setUTCDate(d.getUTCDate() + i);
+      buckets.push({ date: d.toISOString().slice(0, 10), count: 0, issues: [] });
+    }
+    const indexByDate = new Map(buckets.map((b, i) => [b.date, i]));
+
+    if (repoIds.length === 0) {
+      return NextResponse.json({
+        success: true,
+        data: { daily: buckets, total: 0, avgPerDay: 0, bestDay: null },
+      });
+    }
+
+    let accessToken: string | null = null;
+    if (userId) {
+      const account = await prisma.account.findFirst({
+        where: { userId, provider: "github" },
+        select: { access_token: true },
+      });
+      accessToken = account?.access_token ?? null;
+    }
+
+    const repos = await prisma.repo.findMany({
+      where: { id: { in: repoIds } },
+      select: { fullName: true },
+    });
+
+    const since = startDate.toISOString();
+
+    await Promise.all(
+      repos.map(async (repo) => {
+        try {
+          const headers: Record<string, string> = {
+            Accept: "application/vnd.github+json",
+          };
+          if (accessToken) headers.Authorization = `Bearer ${accessToken}`;
+
+          let page = 1;
+          while (page <= 5) {
+            const res = await fetch(
+              `https://api.github.com/repos/${repo.fullName}/issues?state=closed&sort=updated&direction=desc&per_page=100&page=${page}&since=${since}`,
+              { headers }
+            );
+            if (!res.ok) break;
+            const items = (await res.json()) as GithubIssue[];
+            if (items.length === 0) break;
+
+            let foundOlder = false;
+            for (const item of items) {
+              if (item.pull_request || !item.closed_at) continue;
+              const closedDate = item.closed_at.slice(0, 10);
+              if (closedDate < startDate.toISOString().slice(0, 10)) {
+                foundOlder = true;
+                continue;
+              }
+              const idx = indexByDate.get(closedDate);
+              if (idx !== undefined) {
+                buckets[idx].count++;
+                if (buckets[idx].issues.length < 5) {
+                  buckets[idx].issues.push({
+                    number: item.number,
+                    title: item.title,
+                    url: item.html_url,
+                    repoFullName: repo.fullName,
+                  });
+                }
+              }
+            }
+
+            if (foundOlder || items.length < 100) break;
+            page++;
+          }
+        } catch {
+          // fail silently per repo
+        }
+      })
+    );
+
+    const total = buckets.reduce((sum, b) => sum + b.count, 0);
+    const avgPerDay = Math.round((total / days) * 10) / 10;
+    const best = buckets.reduce((max, b) => (b.count > max.count ? b : max), buckets[0]);
+    const bestDay = best.count > 0 ? { date: best.date, count: best.count } : null;
+
+    return NextResponse.json({
+      success: true,
+      data: { daily: buckets, total, avgPerDay, bestDay },
+    });
+  } catch (error) {
+    console.error("Fetch issues-closed analytics error:", error);
+    return NextResponse.json({ success: false, error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/apps/web/app/api/v1/repos/workflow-runs/route.ts
+++ b/apps/web/app/api/v1/repos/workflow-runs/route.ts
@@ -5,7 +5,7 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import { listWorkflowRuns, type WorkflowRun } from "@/lib/github";
 
-export interface RepoWorkflowRuns {
+interface RepoWorkflowRuns {
   repoId: string;
   repoFullName: string;
   runs: WorkflowRun[];

--- a/apps/web/app/dashboard/analytics/issues-closed-analytics.tsx
+++ b/apps/web/app/dashboard/analytics/issues-closed-analytics.tsx
@@ -169,40 +169,37 @@ export function IssuesClosedAnalytics() {
             </div>
           ) : (
             <div className="flex flex-col gap-2">
-              {/* Chart area */}
-              <div className="flex items-end gap-0.5 h-40 overflow-x-auto pb-1">
-                {barData.map((bucket) => {
-                  const heightPct = maxCount > 0 ? (bucket.count / maxCount) * 100 : 0;
-                  const isHovered = hoveredDay?.date === bucket.date;
-                  return (
-                    <div
-                      key={bucket.date}
-                      className="group relative flex-1 min-w-1.5 flex flex-col items-center justify-end h-full cursor-pointer"
-                      onMouseEnter={() => setHoveredDay(bucket)}
-                      onMouseLeave={() => setHoveredDay(null)}
-                    >
-                      {/* Tooltip */}
-                      {isHovered && (
-                        <div className="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 z-30 pointer-events-none whitespace-nowrap rounded-md bg-popover text-popover-foreground border border-border px-2.5 py-1.5 text-[11px] font-mono shadow-lg">
+              {/* Chart area — overflow-visible so tooltips don't get clipped */}
+              <div className="overflow-x-auto">
+                <div className="flex items-end gap-0.5 h-40 pb-1 min-w-full">
+                  {barData.map((bucket) => {
+                    const heightPct = maxCount > 0 ? (bucket.count / maxCount) * 100 : 0;
+                    return (
+                      <div
+                        key={bucket.date}
+                        className="group/bar relative flex-1 min-w-1.5 flex flex-col items-center justify-end h-full cursor-pointer"
+                        onMouseEnter={() => setHoveredDay(bucket)}
+                        onMouseLeave={() => setHoveredDay(null)}
+                      >
+                        {/* CSS-only tooltip — no state, no re-render, no flicker */}
+                        <div className="absolute bottom-[calc(100%+8px)] left-1/2 -translate-x-1/2 z-30 pointer-events-none whitespace-nowrap rounded-md bg-popover text-popover-foreground border border-border px-2.5 py-1.5 text-[11px] font-mono shadow-lg opacity-0 group-hover/bar:opacity-100 transition-opacity duration-100">
                           <div className="font-semibold text-primary">{bucket.count} closed</div>
                           <div className="text-muted-foreground">{formatDateFull(bucket.date)}</div>
                           <span className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-border" />
                         </div>
-                      )}
-                      <div
-                        className={cn(
-                          "w-full rounded-t-[2px] transition-colors",
-                          bucket.count === 0
-                            ? "bg-muted/50 border border-border/40"
-                            : isHovered
-                            ? "bg-primary shadow-[0_0_8px_rgba(34,211,238,0.5)]"
-                            : "bg-primary/60 hover:bg-primary/80"
-                        )}
-                        style={{ height: `${Math.max(bucket.count > 0 ? 4 : 2, heightPct)}%` }}
-                      />
-                    </div>
-                  );
-                })}
+                        <div
+                          className={cn(
+                            "w-full rounded-t-xs transition-colors group-hover/bar:bg-primary group-hover/bar:shadow-[0_0_8px_rgba(34,211,238,0.5)]",
+                            bucket.count === 0
+                              ? "bg-muted/50 border border-border/40"
+                              : "bg-primary/60"
+                          )}
+                          style={{ height: `${Math.max(bucket.count > 0 ? 4 : 2, heightPct)}%` }}
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
               </div>
 
               {/* X-axis labels */}

--- a/apps/web/app/dashboard/analytics/issues-closed-analytics.tsx
+++ b/apps/web/app/dashboard/analytics/issues-closed-analytics.tsx
@@ -302,8 +302,6 @@ export function IssuesClosedAnalytics() {
                   <div
                     key={bucket.date}
                     className="flex items-center justify-between px-5 py-2.5 hover:bg-muted/40 transition-colors"
-                    onMouseEnter={() => setHoveredDay(bucket)}
-                    onMouseLeave={() => setHoveredDay(null)}
                   >
                     <span className="text-sm font-mono text-foreground">
                       {formatDateFull(bucket.date)}

--- a/apps/web/app/dashboard/analytics/issues-closed-analytics.tsx
+++ b/apps/web/app/dashboard/analytics/issues-closed-analytics.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useCallback, memo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 import Link from "next/link";
@@ -47,9 +47,77 @@ function formatDateFull(iso: string) {
   return `${MONTHS[d.getUTCMonth()]} ${d.getUTCDate()}, ${d.getUTCFullYear()}`;
 }
 
+// Memoized so it never re-renders when parent hoveredDay state changes.
+// That's the only way to keep CSS :hover stable while parent re-renders.
+const BarList = memo(function BarList({
+  barData,
+  maxCount,
+  tickDates,
+  onHover,
+}: {
+  barData: DayBucket[];
+  maxCount: number;
+  tickDates: string[];
+  onHover: (bucket: DayBucket | null) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      {/* No overflow wrapper — overflow clips tooltips on both axes */}
+      <div className="flex items-end gap-0.5 h-40 pb-1 w-full">
+        {barData.map((bucket) => {
+          const heightPct = maxCount > 0 ? (bucket.count / maxCount) * 100 : 0;
+          return (
+            <div
+              key={bucket.date}
+              className="group/bar relative flex-1 min-w-0 flex flex-col items-center justify-end h-full cursor-pointer"
+              onMouseEnter={() => onHover(bucket)}
+              onMouseLeave={() => onHover(null)}
+            >
+              {/* CSS-only tooltip: opacity transition, zero state, zero re-render */}
+              <div className="absolute bottom-[calc(100%+8px)] left-1/2 -translate-x-1/2 z-30 pointer-events-none whitespace-nowrap rounded-md bg-popover text-popover-foreground border border-border px-2.5 py-1.5 text-[11px] font-mono shadow-lg opacity-0 group-hover/bar:opacity-100 transition-opacity duration-100">
+                <div className="font-semibold text-primary">{bucket.count} closed</div>
+                <div className="text-muted-foreground">{formatDateFull(bucket.date)}</div>
+                <span className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-border" />
+              </div>
+              <div
+                className={cn(
+                  "w-full rounded-t-xs transition-colors group-hover/bar:bg-primary group-hover/bar:shadow-[0_0_8px_rgba(34,211,238,0.5)]",
+                  bucket.count === 0 ? "bg-muted/50 border border-border/40" : "bg-primary/60"
+                )}
+                style={{ height: `${Math.max(bucket.count > 0 ? 4 : 2, heightPct)}%` }}
+              />
+            </div>
+          );
+        })}
+      </div>
+
+      {/* X-axis labels */}
+      <div className="flex items-end gap-0.5 w-full">
+        {barData.map((bucket) => {
+          const showTick = tickDates.includes(bucket.date);
+          return (
+            <div key={bucket.date} className="flex-1 min-w-0 flex justify-center">
+              {showTick && (
+                <span className="text-[9px] font-mono text-muted-foreground/70 whitespace-nowrap -rotate-45 origin-top-left ml-1">
+                  {formatDate(bucket.date)}
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+});
+
 export function IssuesClosedAnalytics() {
   const [days, setDays] = useState<7 | 30 | 90>(30);
   const [hoveredDay, setHoveredDay] = useState<DayBucket | null>(null);
+
+  // Stable callback — BarList memo only works if onHover ref is stable
+  const handleHover = useCallback((bucket: DayBucket | null) => {
+    setHoveredDay(bucket);
+  }, []);
 
   const { data, isLoading } = useQuery<AnalyticsData>({
     queryKey: ["issues-closed-analytics", days],
@@ -64,17 +132,13 @@ export function IssuesClosedAnalytics() {
   const { barData, maxCount, tickDates } = useMemo(() => {
     if (!data?.daily.length) return { barData: [], maxCount: 1, tickDates: [] as string[] };
     const max = Math.max(1, ...data.daily.map((d) => d.count));
-
     const step = days === 7 ? 1 : days === 30 ? 5 : 15;
     const ticks: string[] = [];
     data.daily.forEach((d, i) => {
       if (i % step === 0) ticks.push(d.date);
     });
-
     return { barData: data.daily, maxCount: max, tickDates: ticks };
   }, [data, days]);
-
-  const displayed = hoveredDay ?? null;
 
   return (
     <div className="flex flex-col gap-6 md:gap-8">
@@ -148,7 +212,7 @@ export function IssuesClosedAnalytics() {
             backgroundSize: "40px 40px",
           }}
         />
-        <CardContent className="relative z-10 p-6 space-y-4">
+        <CardContent className="relative z-10 p-6 space-y-4 overflow-visible">
           <div className="flex items-center justify-between">
             <h2 className="text-sm font-medium text-foreground flex items-center gap-2">
               <Calendar className="h-4 w-4 text-primary" />
@@ -168,73 +232,29 @@ export function IssuesClosedAnalytics() {
               No closed issues found. Connect a GitHub repo to get started.
             </div>
           ) : (
-            <div className="flex flex-col gap-2">
-              {/* Chart area — overflow-visible so tooltips don't get clipped */}
-              <div className="overflow-x-auto">
-                <div className="flex items-end gap-0.5 h-40 pb-1 min-w-full">
-                  {barData.map((bucket) => {
-                    const heightPct = maxCount > 0 ? (bucket.count / maxCount) * 100 : 0;
-                    return (
-                      <div
-                        key={bucket.date}
-                        className="group/bar relative flex-1 min-w-1.5 flex flex-col items-center justify-end h-full cursor-pointer"
-                        onMouseEnter={() => setHoveredDay(bucket)}
-                        onMouseLeave={() => setHoveredDay(null)}
-                      >
-                        {/* CSS-only tooltip — no state, no re-render, no flicker */}
-                        <div className="absolute bottom-[calc(100%+8px)] left-1/2 -translate-x-1/2 z-30 pointer-events-none whitespace-nowrap rounded-md bg-popover text-popover-foreground border border-border px-2.5 py-1.5 text-[11px] font-mono shadow-lg opacity-0 group-hover/bar:opacity-100 transition-opacity duration-100">
-                          <div className="font-semibold text-primary">{bucket.count} closed</div>
-                          <div className="text-muted-foreground">{formatDateFull(bucket.date)}</div>
-                          <span className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-border" />
-                        </div>
-                        <div
-                          className={cn(
-                            "w-full rounded-t-xs transition-colors group-hover/bar:bg-primary group-hover/bar:shadow-[0_0_8px_rgba(34,211,238,0.5)]",
-                            bucket.count === 0
-                              ? "bg-muted/50 border border-border/40"
-                              : "bg-primary/60"
-                          )}
-                          style={{ height: `${Math.max(bucket.count > 0 ? 4 : 2, heightPct)}%` }}
-                        />
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-
-              {/* X-axis labels */}
-              <div className="flex items-end gap-0.5 overflow-x-auto">
-                {barData.map((bucket) => {
-                  const showTick = tickDates.includes(bucket.date);
-                  return (
-                    <div key={bucket.date} className="flex-1 min-w-1.5 flex justify-center">
-                      {showTick && (
-                        <span className="text-[9px] font-mono text-muted-foreground/70 whitespace-nowrap -rotate-45 origin-top-left ml-1">
-                          {formatDate(bucket.date)}
-                        </span>
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
+            <BarList
+              barData={barData}
+              maxCount={maxCount}
+              tickDates={tickDates}
+              onHover={handleHover}
+            />
           )}
         </CardContent>
       </Card>
 
       {/* Hovered day issue list */}
-      {displayed && displayed.issues.length > 0 && (
+      {hoveredDay && hoveredDay.issues.length > 0 && (
         <Card>
           <CardContent className="p-5 space-y-3">
             <h3 className="text-sm font-medium text-foreground">
               Closed on{" "}
-              <span className="text-primary font-mono">{formatDateFull(displayed.date)}</span>
+              <span className="text-primary font-mono">{formatDateFull(hoveredDay.date)}</span>
               <span className="ml-2 text-muted-foreground font-mono text-xs">
-                {displayed.count} issue{displayed.count === 1 ? "" : "s"}
+                {hoveredDay.count} issue{hoveredDay.count === 1 ? "" : "s"}
               </span>
             </h3>
             <ul className="space-y-1.5">
-              {displayed.issues.map((issue) => (
+              {hoveredDay.issues.map((issue) => (
                 <li key={`${issue.repoFullName}-${issue.number}`}>
                   <Link
                     href={issue.url}
@@ -254,9 +274,9 @@ export function IssuesClosedAnalytics() {
                   </Link>
                 </li>
               ))}
-              {displayed.count > displayed.issues.length && (
+              {hoveredDay.count > hoveredDay.issues.length && (
                 <li className="text-[11px] font-mono text-muted-foreground/60 pl-5">
-                  +{displayed.count - displayed.issues.length} more issues
+                  +{hoveredDay.count - hoveredDay.issues.length} more issues
                 </li>
               )}
             </ul>

--- a/apps/web/app/dashboard/analytics/issues-closed-analytics.tsx
+++ b/apps/web/app/dashboard/analytics/issues-closed-analytics.tsx
@@ -1,0 +1,356 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import Link from "next/link";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  CheckCircle2,
+  TrendingUp,
+  Calendar,
+  Loader2,
+  ExternalLink,
+  BarChart3,
+  Zap,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface DayBucket {
+  date: string;
+  count: number;
+  issues: { number: number; title: string; url: string; repoFullName: string }[];
+}
+
+interface AnalyticsData {
+  daily: DayBucket[];
+  total: number;
+  avgPerDay: number;
+  bestDay: { date: string; count: number } | null;
+}
+
+const RANGE_OPTIONS = [
+  { label: "7D", days: 7 },
+  { label: "30D", days: 30 },
+  { label: "90D", days: 90 },
+] as const;
+
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+function formatDate(iso: string) {
+  const d = new Date(iso + "T00:00:00Z");
+  return `${MONTHS[d.getUTCMonth()]} ${d.getUTCDate()}`;
+}
+
+function formatDateFull(iso: string) {
+  const d = new Date(iso + "T00:00:00Z");
+  return `${MONTHS[d.getUTCMonth()]} ${d.getUTCDate()}, ${d.getUTCFullYear()}`;
+}
+
+export function IssuesClosedAnalytics() {
+  const [days, setDays] = useState<7 | 30 | 90>(30);
+  const [hoveredDay, setHoveredDay] = useState<DayBucket | null>(null);
+
+  const { data, isLoading } = useQuery<AnalyticsData>({
+    queryKey: ["issues-closed-analytics", days],
+    queryFn: async () => {
+      const { data } = await axios.get(`/api/v1/reports/analytics/issues-closed?days=${days}`);
+      return data.data;
+    },
+    staleTime: 2 * 60_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const { barData, maxCount, tickDates } = useMemo(() => {
+    if (!data?.daily.length) return { barData: [], maxCount: 1, tickDates: [] as string[] };
+    const max = Math.max(1, ...data.daily.map((d) => d.count));
+
+    const step = days === 7 ? 1 : days === 30 ? 5 : 15;
+    const ticks: string[] = [];
+    data.daily.forEach((d, i) => {
+      if (i % step === 0) ticks.push(d.date);
+    });
+
+    return { barData: data.daily, maxCount: max, tickDates: ticks };
+  }, [data, days]);
+
+  const displayed = hoveredDay ?? null;
+
+  return (
+    <div className="flex flex-col gap-6 md:gap-8">
+      {/* Terminal header */}
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between text-xs font-mono text-muted-foreground border-b border-border pb-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <BarChart3 className="h-4 w-4 text-primary shrink-0" />
+          <span className="truncate">~/glitchgrab/analytics/issues-closed</span>
+        </div>
+        <div className="flex items-center gap-1.5 bg-card rounded border border-border p-0.5">
+          {RANGE_OPTIONS.map((opt) => (
+            <button
+              key={opt.days}
+              type="button"
+              onClick={() => setDays(opt.days)}
+              className={cn(
+                "font-mono text-[11px] px-2.5 py-1 rounded transition-colors",
+                days === opt.days
+                  ? "bg-primary/20 text-primary border border-primary/40"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Page heading */}
+      <div className="flex flex-col gap-1">
+        <h1 className="text-2xl md:text-3xl font-medium tracking-tight text-foreground">
+          Issue Closure Analytics
+        </h1>
+        <p className="text-sm font-mono text-muted-foreground">
+          Day-wise GitHub issues closed across all connected repos
+        </p>
+      </div>
+
+      {/* Stat cards */}
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+        <StatCard
+          label="Total closed"
+          value={isLoading ? null : (data?.total ?? 0)}
+          icon={<CheckCircle2 className="h-4 w-4" />}
+          sub={`last ${days} days`}
+        />
+        <StatCard
+          label="Avg / day"
+          value={isLoading ? null : (data?.avgPerDay ?? 0)}
+          icon={<TrendingUp className="h-4 w-4" />}
+          sub="issues closed"
+          decimal
+        />
+        <StatCard
+          label="Best day"
+          value={isLoading ? null : (data?.bestDay?.count ?? 0)}
+          icon={<Zap className="h-4 w-4" />}
+          sub={data?.bestDay ? formatDate(data.bestDay.date) : "—"}
+          className="col-span-2 md:col-span-1"
+        />
+      </div>
+
+      {/* Bar chart */}
+      <Card className="relative overflow-hidden">
+        <div
+          aria-hidden
+          className="absolute inset-0 z-0 opacity-15 pointer-events-none"
+          style={{
+            backgroundImage:
+              "linear-gradient(to right, var(--border) 1px, transparent 1px), linear-gradient(to bottom, var(--border) 1px, transparent 1px)",
+            backgroundSize: "40px 40px",
+          }}
+        />
+        <CardContent className="relative z-10 p-6 space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-sm font-medium text-foreground flex items-center gap-2">
+              <Calendar className="h-4 w-4 text-primary" />
+              Issues closed per day
+            </h2>
+            <span className="text-[11px] font-mono text-muted-foreground">
+              {days === 7 ? "Last 7 days" : days === 30 ? "Last 30 days" : "Last 90 days"}
+            </span>
+          </div>
+
+          {isLoading ? (
+            <div className="flex items-center justify-center py-20">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : barData.length === 0 ? (
+            <div className="text-xs font-mono text-muted-foreground text-center py-14 border border-dashed border-border rounded">
+              No closed issues found. Connect a GitHub repo to get started.
+            </div>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {/* Chart area */}
+              <div className="flex items-end gap-0.5 h-40 overflow-x-auto pb-1">
+                {barData.map((bucket) => {
+                  const heightPct = maxCount > 0 ? (bucket.count / maxCount) * 100 : 0;
+                  const isHovered = hoveredDay?.date === bucket.date;
+                  return (
+                    <div
+                      key={bucket.date}
+                      className="group relative flex-1 min-w-1.5 flex flex-col items-center justify-end h-full cursor-pointer"
+                      onMouseEnter={() => setHoveredDay(bucket)}
+                      onMouseLeave={() => setHoveredDay(null)}
+                    >
+                      {/* Tooltip */}
+                      {isHovered && (
+                        <div className="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 z-30 pointer-events-none whitespace-nowrap rounded-md bg-popover text-popover-foreground border border-border px-2.5 py-1.5 text-[11px] font-mono shadow-lg">
+                          <div className="font-semibold text-primary">{bucket.count} closed</div>
+                          <div className="text-muted-foreground">{formatDateFull(bucket.date)}</div>
+                          <span className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-border" />
+                        </div>
+                      )}
+                      <div
+                        className={cn(
+                          "w-full rounded-t-[2px] transition-colors",
+                          bucket.count === 0
+                            ? "bg-muted/50 border border-border/40"
+                            : isHovered
+                            ? "bg-primary shadow-[0_0_8px_rgba(34,211,238,0.5)]"
+                            : "bg-primary/60 hover:bg-primary/80"
+                        )}
+                        style={{ height: `${Math.max(bucket.count > 0 ? 4 : 2, heightPct)}%` }}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+
+              {/* X-axis labels */}
+              <div className="flex items-end gap-0.5 overflow-x-auto">
+                {barData.map((bucket) => {
+                  const showTick = tickDates.includes(bucket.date);
+                  return (
+                    <div key={bucket.date} className="flex-1 min-w-1.5 flex justify-center">
+                      {showTick && (
+                        <span className="text-[9px] font-mono text-muted-foreground/70 whitespace-nowrap -rotate-45 origin-top-left ml-1">
+                          {formatDate(bucket.date)}
+                        </span>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Hovered day issue list */}
+      {displayed && displayed.issues.length > 0 && (
+        <Card>
+          <CardContent className="p-5 space-y-3">
+            <h3 className="text-sm font-medium text-foreground">
+              Closed on{" "}
+              <span className="text-primary font-mono">{formatDateFull(displayed.date)}</span>
+              <span className="ml-2 text-muted-foreground font-mono text-xs">
+                {displayed.count} issue{displayed.count === 1 ? "" : "s"}
+              </span>
+            </h3>
+            <ul className="space-y-1.5">
+              {displayed.issues.map((issue) => (
+                <li key={`${issue.repoFullName}-${issue.number}`}>
+                  <Link
+                    href={issue.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-2 group text-sm text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-green-400" />
+                    <span className="font-mono text-[11px] text-muted-foreground/60 shrink-0">
+                      #{issue.number}
+                    </span>
+                    <span className="truncate flex-1">{issue.title}</span>
+                    <span className="text-[10px] font-mono text-muted-foreground/50 shrink-0">
+                      {issue.repoFullName}
+                    </span>
+                    <ExternalLink className="h-3 w-3 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
+                  </Link>
+                </li>
+              ))}
+              {displayed.count > displayed.issues.length && (
+                <li className="text-[11px] font-mono text-muted-foreground/60 pl-5">
+                  +{displayed.count - displayed.issues.length} more issues
+                </li>
+              )}
+            </ul>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Daily breakdown table */}
+      {!isLoading && data && data.total > 0 && (
+        <Card>
+          <CardContent className="p-0">
+            <div className="flex items-center justify-between px-5 py-3 border-b border-border">
+              <h3 className="text-sm font-medium text-foreground">Daily breakdown</h3>
+              <span className="text-[11px] font-mono text-muted-foreground">
+                {data.daily.filter((d) => d.count > 0).length} active days
+              </span>
+            </div>
+            <div className="divide-y divide-border max-h-72 overflow-y-auto">
+              {[...data.daily]
+                .filter((d) => d.count > 0)
+                .sort((a, b) => b.date.localeCompare(a.date))
+                .map((bucket) => (
+                  <div
+                    key={bucket.date}
+                    className="flex items-center justify-between px-5 py-2.5 hover:bg-muted/40 transition-colors"
+                    onMouseEnter={() => setHoveredDay(bucket)}
+                    onMouseLeave={() => setHoveredDay(null)}
+                  >
+                    <span className="text-sm font-mono text-foreground">
+                      {formatDateFull(bucket.date)}
+                    </span>
+                    <div className="flex items-center gap-3">
+                      <div className="flex gap-0.5">
+                        {Array.from({ length: Math.min(5, bucket.count) }).map((_, i) => (
+                          <div key={i} className="h-2 w-2 rounded-full bg-primary/70" />
+                        ))}
+                        {bucket.count > 5 && (
+                          <span className="text-[10px] font-mono text-muted-foreground ml-1">
+                            +{bucket.count - 5}
+                          </span>
+                        )}
+                      </div>
+                      <span className="font-mono text-sm tabular-nums text-foreground w-8 text-right">
+                        {bucket.count}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  icon,
+  sub,
+  decimal,
+  className,
+}: {
+  label: string;
+  value: number | null;
+  icon: React.ReactNode;
+  sub: string;
+  decimal?: boolean;
+  className?: string;
+}) {
+  return (
+    <Card className={className}>
+      <CardContent className="p-4 md:p-5">
+        <div className="flex items-start justify-between mb-3">
+          <span className="text-[10px] font-mono uppercase tracking-[0.15em] text-muted-foreground">
+            {label}
+          </span>
+          <span className="text-muted-foreground/60">{icon}</span>
+        </div>
+        <div className="flex items-baseline gap-2">
+          {value === null ? (
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          ) : (
+            <span className="text-3xl font-mono tabular-nums font-medium text-foreground">
+              {decimal ? value.toFixed(1) : String(value).padStart(2, "0")}
+            </span>
+          )}
+          <span className="text-[11px] font-mono text-muted-foreground">{sub}</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/app/dashboard/analytics/issues-closed-analytics.tsx
+++ b/apps/web/app/dashboard/analytics/issues-closed-analytics.tsx
@@ -91,14 +91,14 @@ const BarList = memo(function BarList({
         })}
       </div>
 
-      {/* X-axis labels */}
-      <div className="flex items-end gap-0.5 w-full">
+      {/* X-axis labels — absolute so rotation doesn't get clipped by flex container */}
+      <div className="flex gap-0.5 w-full h-7">
         {barData.map((bucket) => {
           const showTick = tickDates.includes(bucket.date);
           return (
-            <div key={bucket.date} className="flex-1 min-w-0 flex justify-center">
+            <div key={bucket.date} className="relative flex-1 min-w-0">
               {showTick && (
-                <span className="text-[9px] font-mono text-muted-foreground/70 whitespace-nowrap -rotate-45 origin-top-left ml-1">
+                <span className="absolute left-0 top-0 text-[9px] font-mono text-muted-foreground/70 whitespace-nowrap -rotate-45 origin-top-left">
                   {formatDate(bucket.date)}
                 </span>
               )}

--- a/apps/web/app/dashboard/analytics/page.tsx
+++ b/apps/web/app/dashboard/analytics/page.tsx
@@ -1,0 +1,7 @@
+import { IssuesClosedAnalytics } from "./issues-closed-analytics";
+
+export const metadata = { title: "Analytics · Glitchgrab" };
+
+export default function AnalyticsPage() {
+  return <IssuesClosedAnalytics />;
+}

--- a/apps/web/app/dashboard/billing/page.tsx
+++ b/apps/web/app/dashboard/billing/page.tsx
@@ -4,7 +4,6 @@ import { auth } from "@/lib/auth";
 import { getUserPlan } from "@/lib/billing";
 import { InnerPageHeader } from "@/components/dashboard/inner-page-header";
 import {
-  CreditCard,
   CheckCircle2,
   Crown,
   Clock,
@@ -58,8 +57,6 @@ export default async function BillingPage() {
   return (
     <div className="space-y-6">
       <InnerPageHeader
-        segment="billing"
-        icon={CreditCard}
         title="billing"
         subtitle={subtitle}
         meta={meta}

--- a/apps/web/app/dashboard/collaborators/page.tsx
+++ b/apps/web/app/dashboard/collaborators/page.tsx
@@ -46,8 +46,6 @@ export default async function CollaboratorsPage() {
   return (
     <div className="space-y-6">
       <InnerPageHeader
-        segment="collaborators"
-        icon={Users}
         title="collaborators"
         subtitle="Invite people to report bugs on your repos — no GitHub account needed"
         meta={

--- a/apps/web/app/dashboard/dashboard-analytics.tsx
+++ b/apps/web/app/dashboard/dashboard-analytics.tsx
@@ -153,8 +153,8 @@ export function DashboardAnalytics({ userName }: { userName: string }) {
       </div>
 
       {/* Stat grid (3×2) + active workflows widget */}
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-4 lg:gap-6">
-        <section className="grid grid-cols-2 md:grid-cols-3 gap-3 lg:col-span-3">
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3 lg:gap-6">
+        <section className="grid grid-cols-2 md:grid-cols-3 gap-3 lg:col-span-2">
           <StatCard
             label="PRs to review"
             value={openPrs}

--- a/apps/web/app/dashboard/dashboard-analytics.tsx
+++ b/apps/web/app/dashboard/dashboard-analytics.tsx
@@ -8,11 +8,13 @@ import {
   AlertCircle,
   AlertTriangle,
   Bug,
+  CheckCircle2,
   CircleDashed,
   GitBranch,
   GitPullRequest,
   Loader2,
   TerminalSquare,
+  TrendingUp,
 } from "lucide-react";
 import { OpenPullRequests } from "./open-pull-requests";
 import { OpenIssues } from "./open-issues";
@@ -26,6 +28,13 @@ interface AnalyticsData {
   avgPerDay: number;
   today: number;
   failed: number;
+}
+
+interface ClosedData {
+  daily: { date: string; count: number }[];
+  total: number;
+  avgPerDay: number;
+  bestDay: { date: string; count: number } | null;
 }
 
 interface PullRequest { repoFullName: string; number: number }
@@ -66,6 +75,17 @@ export function DashboardAnalytics({ userName }: { userName: string }) {
     staleTime: 60_000,
     refetchOnWindowFocus: true,
     refetchInterval: 60_000,
+  });
+
+  const { data: closed } = useQuery<ClosedData>({
+    queryKey: ["issues-closed-analytics", 7],
+    queryFn: async () => {
+      const { data } = await axios.get("/api/v1/reports/analytics/issues-closed?days=7");
+      return data.data;
+    },
+    staleTime: 5 * 60_000,
+    refetchOnWindowFocus: true,
+    refetchInterval: 5 * 60_000,
   });
 
   const { data: contrib } = useQuery<{ total: number; login: string | null; weeks: unknown[] }>({
@@ -132,9 +152,9 @@ export function DashboardAnalytics({ userName }: { userName: string }) {
         </p>
       </div>
 
-      {/* Stat grid + active workflows widget */}
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3 lg:gap-6">
-        <section className="grid grid-cols-2 gap-3 lg:col-span-2">
+      {/* Stat grid (3×2) + active workflows widget */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-4 lg:gap-6">
+        <section className="grid grid-cols-2 md:grid-cols-3 gap-3 lg:col-span-3">
           <StatCard
             label="PRs to review"
             value={openPrs}
@@ -146,6 +166,13 @@ export function DashboardAnalytics({ userName }: { userName: string }) {
             value={openIssues}
             icon={<AlertCircle className="h-4 w-4" />}
             pill={openIssues > 0 ? { text: "Triage", tone: "primary" } : { text: "Clear", tone: "muted" }}
+          />
+          <StatCard
+            label="Closed this week"
+            value={closed?.total ?? 0}
+            icon={<CheckCircle2 className="h-4 w-4" />}
+            pill={{ text: "last 7 days", tone: "muted" }}
+            href="/dashboard/analytics"
           />
           <StatCard
             label="New reports"
@@ -164,6 +191,14 @@ export function DashboardAnalytics({ userName }: { userName: string }) {
                 : { text: "None", tone: "muted" }
             }
             href={analytics.failed > 0 ? "/dashboard/reports" : undefined}
+          />
+          <StatCard
+            label="Avg closed / day"
+            value={closed?.avgPerDay ?? 0}
+            icon={<TrendingUp className="h-4 w-4" />}
+            pill={{ text: "7-day avg", tone: "muted" }}
+            href="/dashboard/analytics"
+            decimal
           />
         </section>
 
@@ -254,6 +289,7 @@ function StatCard({
   pill,
   critical,
   href,
+  decimal,
 }: {
   label: string;
   value: number;
@@ -261,6 +297,7 @@ function StatCard({
   pill: { text: string; tone: PillTone };
   critical?: boolean;
   href?: string;
+  decimal?: boolean;
 }) {
   const toneClasses: Record<PillTone, string> = {
     primary: "text-primary bg-primary/10 border-primary/20",
@@ -297,7 +334,7 @@ function StatCard({
               critical ? "text-red-400" : "text-foreground"
             }`}
           >
-            {value < 100 ? String(value).padStart(2, "0") : value}
+            {decimal ? value.toFixed(1) : value < 100 ? String(value).padStart(2, "0") : value}
           </span>
           <span
             className={`text-[10px] font-mono px-2 py-0.5 rounded border ${toneClasses[pill.tone]}`}

--- a/apps/web/app/dashboard/dashboard-analytics.tsx
+++ b/apps/web/app/dashboard/dashboard-analytics.tsx
@@ -315,8 +315,8 @@ function StatCard({
       }`}
     >
       {critical && <div className="absolute top-0 left-0 right-0 h-0.5 bg-red-500/60" />}
-      <CardContent className="p-4 md:p-5">
-        <div className="flex items-start justify-between mb-3">
+      <CardContent className="p-3">
+        <div className="flex items-start justify-between mb-1.5">
           <span
             className={`text-[10px] font-mono uppercase tracking-[0.15em] ${
               critical ? "text-red-400" : "text-muted-foreground"
@@ -324,20 +324,20 @@ function StatCard({
           >
             {label}
           </span>
-          <span className={critical ? "text-red-400/70" : "text-muted-foreground/60"}>
+          <span className={`${critical ? "text-red-400/70" : "text-muted-foreground/60"} [&>svg]:h-3.5 [&>svg]:w-3.5`}>
             {icon}
           </span>
         </div>
-        <div className="flex items-baseline gap-3 flex-wrap">
+        <div className="flex items-baseline gap-2 flex-wrap">
           <span
-            className={`text-3xl md:text-4xl font-mono tabular-nums font-medium ${
+            className={`text-2xl font-mono tabular-nums font-medium ${
               critical ? "text-red-400" : "text-foreground"
             }`}
           >
             {decimal ? value.toFixed(1) : value < 100 ? String(value).padStart(2, "0") : value}
           </span>
           <span
-            className={`text-[10px] font-mono px-2 py-0.5 rounded border ${toneClasses[pill.tone]}`}
+            className={`text-[10px] font-mono px-1.5 py-0.5 rounded border ${toneClasses[pill.tone]}`}
           >
             {pill.text}
           </span>

--- a/apps/web/app/dashboard/dashboard-analytics.tsx
+++ b/apps/web/app/dashboard/dashboard-analytics.tsx
@@ -10,10 +10,8 @@ import {
   Bug,
   CheckCircle2,
   CircleDashed,
-  GitBranch,
   GitPullRequest,
   Loader2,
-  TerminalSquare,
   TrendingUp,
 } from "lucide-react";
 import { OpenPullRequests } from "./open-pull-requests";
@@ -113,24 +111,6 @@ export function DashboardAnalytics() {
 
   return (
     <div className="flex flex-col gap-6 md:gap-8">
-      {/* Terminal status bar */}
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between text-xs font-mono text-muted-foreground border-b border-border pb-3">
-        <div className="flex items-center gap-3 min-w-0">
-          <TerminalSquare className="h-4 w-4 text-primary shrink-0" />
-          <span className="truncate">~/glitchgrab/dashboard</span>
-          <span className="hidden sm:inline-flex items-center gap-1 text-[10px] px-2 py-0.5 bg-card rounded border border-border">
-            <GitBranch className="h-3 w-3" /> main
-          </span>
-        </div>
-        <div className="flex items-center gap-2">
-          <span className="relative flex h-2 w-2">
-            <span className="absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-60 animate-ping" />
-            <span className="relative inline-flex h-2 w-2 rounded-full bg-green-400" />
-          </span>
-          <span>System Ops Normal</span>
-        </div>
-      </div>
-
       {/* Stat grid (3×2) + active workflows widget */}
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-3 lg:gap-6">
         <section className="grid grid-cols-2 md:grid-cols-3 gap-3 lg:col-span-2">

--- a/apps/web/app/dashboard/dashboard-analytics.tsx
+++ b/apps/web/app/dashboard/dashboard-analytics.tsx
@@ -44,7 +44,7 @@ function pad2(n: number) {
   return n < 10 && n >= 0 ? `0${n}` : String(n);
 }
 
-export function DashboardAnalytics({ userName }: { userName: string }) {
+export function DashboardAnalytics() {
   const { data: analytics, isLoading: loadingAnalytics } = useQuery<AnalyticsData>({
     queryKey: ["reports-analytics"],
     queryFn: async () => {
@@ -129,27 +129,6 @@ export function DashboardAnalytics({ userName }: { userName: string }) {
           </span>
           <span>System Ops Normal</span>
         </div>
-      </div>
-
-      {/* Header */}
-      <div className="flex flex-col gap-2">
-        <h1 className="text-2xl md:text-3xl font-medium tracking-tight text-foreground">
-          Good to see you, {userName}.
-        </h1>
-        <p className="text-sm font-mono text-muted-foreground leading-relaxed max-w-2xl">
-          {openPrs > 0 && (
-            <>
-              You have <span className="text-primary">{openPrs} open PR{openPrs === 1 ? "" : "s"}</span> awaiting review
-              {openIssues > 0 ? ", and " : "."}
-            </>
-          )}
-          {openIssues > 0 && (
-            <>
-              <span className="text-yellow-400">{openIssues} open issue{openIssues === 1 ? "" : "s"}</span> to triage.
-            </>
-          )}
-          {openPrs === 0 && openIssues === 0 && "Nothing pressing — enjoy the quiet."}
-        </p>
       </div>
 
       {/* Stat grid (3×2) + active workflows widget */}

--- a/apps/web/app/dashboard/dashboard-analytics.tsx
+++ b/apps/web/app/dashboard/dashboard-analytics.tsx
@@ -18,6 +18,7 @@ import { OpenPullRequests } from "./open-pull-requests";
 import { OpenIssues } from "./open-issues";
 import { GithubContributions } from "./github-contributions";
 import { ActiveWorkflowsWidget } from "./active-workflows-widget";
+import { IssuesClosedPreview } from "./issues-closed-preview";
 
 interface AnalyticsData {
   daily: { date: string; count: number }[];
@@ -171,8 +172,8 @@ export function DashboardAnalytics({ userName }: { userName: string }) {
         </div>
       </div>
 
-      {/* Two-column action lists */}
-      <div className="grid grid-cols-1 gap-4 md:gap-6 lg:grid-cols-2">
+      {/* Three-column action lists */}
+      <div className="grid grid-cols-1 gap-4 md:gap-6 lg:grid-cols-3">
         <ListPanel
           icon={<GitPullRequest className="h-4 w-4 text-primary" />}
           title="Awaiting your review"
@@ -190,6 +191,8 @@ export function DashboardAnalytics({ userName }: { userName: string }) {
         >
           <OpenIssues />
         </ListPanel>
+
+        <IssuesClosedPreview />
       </div>
 
       {/* Yearly GitHub contributions heatmap */}

--- a/apps/web/app/dashboard/issues-closed-preview.tsx
+++ b/apps/web/app/dashboard/issues-closed-preview.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import Link from "next/link";
+import { CheckCircle2, ArrowRight, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface DayBucket {
+  date: string;
+  count: number;
+}
+
+interface ClosedData {
+  daily: DayBucket[];
+  total: number;
+  avgPerDay: number;
+  bestDay: { date: string; count: number } | null;
+}
+
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+function fmt(iso: string) {
+  const d = new Date(iso + "T00:00:00Z");
+  return `${MONTHS[d.getUTCMonth()]} ${d.getUTCDate()}`;
+}
+
+export function IssuesClosedPreview() {
+  const { data, isLoading } = useQuery<ClosedData>({
+    queryKey: ["issues-closed-analytics", 14],
+    queryFn: async () => {
+      const { data } = await axios.get("/api/v1/reports/analytics/issues-closed?days=14");
+      return data.data;
+    },
+    staleTime: 5 * 60_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const maxCount = data ? Math.max(1, ...data.daily.map((d) => d.count)) : 1;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between border-b border-border pb-2">
+        <h2 className="text-sm font-medium text-foreground flex items-center gap-2">
+          <CheckCircle2 className="h-4 w-4 text-primary" />
+          Issues closed
+        </h2>
+        <Link
+          href="/dashboard/analytics"
+          className="text-xs font-mono text-muted-foreground hover:text-primary transition-colors flex items-center gap-1"
+        >
+          Full report <ArrowRight className="h-3 w-3" />
+        </Link>
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-6">
+          <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+        </div>
+      ) : !data || data.total === 0 ? (
+        <p className="text-xs font-mono text-muted-foreground py-4 text-center">
+          No issues closed in last 14 days
+        </p>
+      ) : (
+        <>
+          {/* Mini bar chart */}
+          <div className="flex items-end gap-0.5 h-14 w-full">
+            {data.daily.map((bucket) => {
+              const heightPct = (bucket.count / maxCount) * 100;
+              return (
+                <div
+                  key={bucket.date}
+                  title={`${bucket.count} closed · ${fmt(bucket.date)}`}
+                  className={cn(
+                    "group/mini relative flex-1 min-w-0 rounded-t-xs transition-colors cursor-default",
+                    bucket.count === 0
+                      ? "bg-muted/40 border border-border/30"
+                      : "bg-primary/50 hover:bg-primary"
+                  )}
+                  style={{ height: `${Math.max(bucket.count > 0 ? 8 : 3, heightPct)}%` }}
+                />
+              );
+            })}
+          </div>
+
+          {/* Summary row */}
+          <div className="flex items-center justify-between text-[11px] font-mono text-muted-foreground">
+            <span>
+              <span className="text-foreground font-medium">{data.total}</span> closed · 14 days
+            </span>
+            <span>
+              avg <span className="text-foreground">{data.avgPerDay}</span>/day
+            </span>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -6,6 +6,7 @@ import { getCollabSession } from "@/lib/collab-auth";
 import { getUserPlan, getTrialStatus } from "@/lib/billing";
 import type { PlanBadgeType } from "@/components/dashboard/plan-badge";
 import { PaywallGuard } from "@/components/dashboard/paywall-guard";
+import { DashboardStatusBar } from "@/components/dashboard/dashboard-status-bar";
 
 export type UserType = "owner" | "collaborator";
 
@@ -52,6 +53,7 @@ export default async function DashboardLayout({
     <div className="flex h-(--app-height,100vh) bg-background transition-[height] duration-100">
       <Sidebar user={user} userType={userType} planBadge={planBadge} trialDaysLeft={trialDaysLeft} />
       <div className="flex flex-1 flex-col overflow-hidden">
+        <DashboardStatusBar />
         <main className="flex-1 overflow-y-auto p-4 pb-20 md:p-6 md:pb-6">
           <PaywallGuard>{children}</PaywallGuard>
         </main>

--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -8,7 +8,7 @@ import type { PlanBadgeType } from "@/components/dashboard/plan-badge";
 import { PaywallGuard } from "@/components/dashboard/paywall-guard";
 import { DashboardStatusBar } from "@/components/dashboard/dashboard-status-bar";
 
-export type UserType = "owner" | "collaborator";
+type UserType = "owner" | "collaborator";
 
 export default async function DashboardLayout({
   children,

--- a/apps/web/app/dashboard/lib/get-dashboard-context.ts
+++ b/apps/web/app/dashboard/lib/get-dashboard-context.ts
@@ -2,14 +2,14 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import { getCollabSession } from "@/lib/collab-auth";
 
-export interface DashboardRepo {
+interface DashboardRepo {
   id: string;
   fullName: string;
   owner: string;
   name: string;
 }
 
-export interface DashboardContext {
+interface DashboardContext {
   userName: string;
   repos: DashboardRepo[];
   hasOwnerSession: boolean;

--- a/apps/web/app/dashboard/open-issues.tsx
+++ b/apps/web/app/dashboard/open-issues.tsx
@@ -73,7 +73,7 @@ export function OpenIssues() {
   );
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-4 max-h-80 overflow-y-auto pr-1">
       {/* Per-repo summary chips */}
       <div className="flex flex-wrap gap-2">
         {sortedRepos.map(([repo, items]) => {

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -5,11 +5,11 @@ import { NoReposState } from "./components/no-repos-state";
 import { getDashboardContext } from "./lib/get-dashboard-context";
 
 export default async function DashboardPage() {
-  const { repos, userName, hasOwnerSession, hasCollabOnly } = await getDashboardContext();
+  const { repos, hasOwnerSession, hasCollabOnly } = await getDashboardContext();
 
   if (repos.length === 0) {
     return <NoReposState canConnect={hasOwnerSession} collaboratorOnly={hasCollabOnly} />;
   }
 
-  return <DashboardAnalytics userName={userName} />;
+  return <DashboardAnalytics />;
 }

--- a/apps/web/app/dashboard/reports/page.tsx
+++ b/apps/web/app/dashboard/reports/page.tsx
@@ -1,4 +1,3 @@
-import { ClipboardList } from "lucide-react";
 import { auth } from "@/lib/auth";
 import { InnerPageHeader } from "@/components/dashboard/inner-page-header";
 import { ReportsList } from "./reports-list";
@@ -10,8 +9,6 @@ export default async function ReportsPage() {
   return (
     <div className="space-y-6">
       <InnerPageHeader
-        segment="reports"
-        icon={ClipboardList}
         title="reports"
         subtitle={
           isOwner

--- a/apps/web/app/dashboard/repos/page.tsx
+++ b/apps/web/app/dashboard/repos/page.tsx
@@ -1,4 +1,3 @@
-import { LayoutGrid } from "lucide-react";
 import { auth } from "@/lib/auth";
 import { InnerPageHeader } from "@/components/dashboard/inner-page-header";
 import { ConnectRepoDialog } from "./connect-repo-dialog";
@@ -11,8 +10,6 @@ export default async function ReposPage() {
   return (
     <div className="space-y-6">
       <InnerPageHeader
-        segment="repos"
-        icon={LayoutGrid}
         title="repositories"
         subtitle={
           isOwner

--- a/apps/web/app/dashboard/settings/page.tsx
+++ b/apps/web/app/dashboard/settings/page.tsx
@@ -1,6 +1,6 @@
 export const dynamic = "force-dynamic";
 
-import { Settings as SettingsIcon, Github, Shield, Mail, User } from "lucide-react";
+import { Github, Shield, Mail, User } from "lucide-react";
 import { auth } from "@/lib/auth";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { InnerPageHeader } from "@/components/dashboard/inner-page-header";
@@ -13,8 +13,6 @@ export default async function SettingsPage() {
   return (
     <div className="space-y-6">
       <InnerPageHeader
-        segment="settings"
-        icon={SettingsIcon}
         title="settings"
         subtitle="Your account & integration preferences"
         meta="account · webhooks · danger zone"

--- a/apps/web/app/dashboard/tokens/page.tsx
+++ b/apps/web/app/dashboard/tokens/page.tsx
@@ -6,7 +6,6 @@ import {
   ChevronRight,
   GitFork,
   Key,
-  KeyRound,
   Shield,
 } from "lucide-react";
 import { InnerPageHeader } from "@/components/dashboard/inner-page-header";
@@ -38,8 +37,6 @@ export default async function TokensPage() {
   return (
     <div className="space-y-6">
       <InnerPageHeader
-        segment="tokens"
-        icon={KeyRound}
         title="api_tokens"
         subtitle="Manage programmable access keys for the Glitchgrab SDK"
         meta={

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -154,6 +154,26 @@ html {
   height: 1px;
 }
 
+/* Global dark scrollbar */
+::-webkit-scrollbar {
+  width: 4px;
+  height: 4px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 9999px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--muted-foreground);
+}
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
 /* Terminal-style thin scrollbar for horizontal overflow sections */
 .pipeline-scroll::-webkit-scrollbar {
   height: 6px;

--- a/apps/web/components/dashboard/dashboard-status-bar.tsx
+++ b/apps/web/components/dashboard/dashboard-status-bar.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { GitBranch, TerminalSquare } from "lucide-react";
+
+function getSegment(pathname: string) {
+  const parts = pathname.split("/").filter(Boolean);
+  // parts[0] = "dashboard", parts[1] = segment
+  return parts[1] ?? "dashboard";
+}
+
+export function DashboardStatusBar() {
+  const pathname = usePathname();
+  const segment = getSegment(pathname);
+
+  return (
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between text-xs font-mono text-muted-foreground border-b border-border px-4 py-3 md:px-6">
+      <div className="flex items-center gap-3 min-w-0">
+        <TerminalSquare className="h-4 w-4 text-primary shrink-0" />
+        <span className="truncate">~/glitchgrab/{segment}</span>
+        <span className="hidden sm:inline-flex items-center gap-1 text-[10px] px-2 py-0.5 bg-card rounded border border-border">
+          <GitBranch className="h-3 w-3" /> main
+        </span>
+      </div>
+      <div className="flex items-center gap-2">
+        <span className="relative flex h-2 w-2">
+          <span className="absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-60 animate-ping" />
+          <span className="relative inline-flex h-2 w-2 rounded-full bg-green-400" />
+        </span>
+        <span>System Ops Normal</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/dashboard/inner-page-header.tsx
+++ b/apps/web/components/dashboard/inner-page-header.tsx
@@ -1,11 +1,4 @@
-import type { LucideIcon } from "lucide-react";
-import { ChevronRight } from "lucide-react";
-
 interface InnerPageHeaderProps {
-  /** Last segment of the route, e.g. "repos", "tokens". Used in breadcrumb. */
-  segment: string;
-  /** Optional icon for breadcrumb leading. */
-  icon?: LucideIcon;
   /** Big lowercase title (e.g. "api_tokens", "repositories"). */
   title: string;
   /** One-line mono subhead, shown after a vertical divider on desktop. */
@@ -16,14 +9,7 @@ interface InnerPageHeaderProps {
   action?: React.ReactNode;
 }
 
-/**
- * Shared page header for all inner dashboard pages.
- * Breadcrumb + title + mono subhead + primary action.
- * Matches the terminal-dev design vocab (mono metadata, uppercase tracked labels).
- */
 export function InnerPageHeader({
-  segment,
-  icon: Icon,
   title,
   subtitle,
   meta,
@@ -33,13 +19,6 @@ export function InnerPageHeader({
     <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4 pb-6 border-b border-border">
       <div className="flex flex-col sm:flex-row sm:items-end gap-4 sm:gap-6 min-w-0">
         <div className="min-w-0">
-          <div className="font-mono text-[10px] text-muted-foreground mb-1.5 flex items-center gap-1.5 uppercase tracking-widest">
-            {Icon && <Icon className="h-3 w-3 shrink-0" />}
-            <span>/</span>
-            <span>dashboard</span>
-            <ChevronRight className="h-3 w-3 shrink-0" />
-            <span className="text-foreground">{segment}</span>
-          </div>
           <h1 className="text-2xl sm:text-3xl font-medium tracking-tight text-foreground leading-none lowercase">
             {title}
           </h1>

--- a/apps/web/components/dashboard/sidebar.tsx
+++ b/apps/web/components/dashboard/sidebar.tsx
@@ -328,8 +328,8 @@ function NavItemRow({ item, isActive }: { item: NavItem; isActive: boolean }) {
             ? "bg-primary/10 text-foreground font-medium"
             : "text-muted-foreground hover:bg-muted hover:text-foreground",
         )}
-        onMouseEnter={() => iconRef.current?.startAnimation()}
-        onMouseLeave={() => iconRef.current?.stopAnimation()}
+        onMouseEnter={() => { if (typeof (iconRef.current as AnimHandle | null)?.startAnimation === "function") (iconRef.current as AnimHandle).startAnimation(); }}
+        onMouseLeave={() => { if (typeof (iconRef.current as AnimHandle | null)?.stopAnimation === "function") (iconRef.current as AnimHandle).stopAnimation(); }}
       >
         <item.icon
           ref={iconRef}

--- a/apps/web/components/dashboard/sidebar.tsx
+++ b/apps/web/components/dashboard/sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef } from "react";
+import { useRef, useEffect, useCallback } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
@@ -80,6 +80,19 @@ export function Sidebar({
   trialDaysLeft = 0,
 }: SidebarProps) {
   const pathname = usePathname();
+  const reportBtnRef = useRef<HTMLButtonElement>(null);
+
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === "g" && (e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey) {
+      e.preventDefault();
+      reportBtnRef.current?.click();
+    }
+  }, []);
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
 
   // Live counts from TanStack cache (fetched by the dashboard; sidebar just reads)
   const { data: issues } = useQuery<unknown[]>({
@@ -223,6 +236,7 @@ export function Sidebar({
           <ReportButton>
             {({ onClick, capturing }) => (
               <button
+                ref={reportBtnRef}
                 type="button"
                 onClick={onClick}
                 disabled={capturing}
@@ -237,14 +251,14 @@ export function Sidebar({
                   ) : (
                     <>
                       <span className="text-primary group-hover:animate-pulse">{">"}</span>
-                      <Bug className="h-3 w-3" />
+                      <Bug className="h-3 w-3 transition-transform group-hover:rotate-12 group-hover:scale-110" />
                       <span>REPORT_BUG</span>
                     </>
                   )}
                 </span>
                 {!capturing && (
                   <kbd className="font-mono text-[9px] text-muted-foreground bg-card border border-border group-hover:border-muted-foreground/40 rounded px-1.5 py-0.5 leading-none">
-                    ⇧⌘B
+                    ⌘G
                   </kbd>
                 )}
               </button>

--- a/apps/web/components/dashboard/sidebar.tsx
+++ b/apps/web/components/dashboard/sidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRef } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
@@ -204,57 +205,12 @@ export function Sidebar({
                     item.href === "/dashboard"
                       ? pathname === "/dashboard"
                       : pathname.startsWith(item.href);
-
                   return (
-                    <li key={item.href} className="relative">
-                      {isActive && (
-                        <span
-                          aria-hidden
-                          className="absolute left-0 top-1 bottom-1 w-0.75 rounded-r bg-primary shadow-[0_0_6px_rgba(34,211,238,0.5)] z-10"
-                        />
-                      )}
-                      <Link
-                        href={item.href}
-                        prefetch
-                        className={cn(
-                          "group flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm transition-colors",
-                          isActive
-                            ? "bg-primary/10 text-foreground font-medium"
-                            : "text-muted-foreground hover:bg-muted hover:text-foreground",
-                        )}
-                      >
-                        <item.icon
-                          size={16}
-                          className={cn(
-                            "shrink-0 transition-colors",
-                            isActive
-                              ? "text-primary"
-                              : "text-muted-foreground group-hover:text-foreground",
-                          )}
-                        />
-                        <span className="truncate flex-1">{item.label}</span>
-                        {item.badge && (
-                          <span
-                            className={cn(
-                              "font-mono text-[9px] px-1.5 py-0.5 rounded border leading-none tabular-nums uppercase tracking-wide",
-                              TONE_CLASS[item.badge.tone],
-                            )}
-                          >
-                            {item.badge.text}
-                          </span>
-                        )}
-                        {item.kbd && !isActive && !item.badge && (
-                          <kbd
-                            className={cn(
-                              "font-mono text-[9px] px-1.5 py-0.5 rounded bg-background border border-border text-muted-foreground/50 leading-none transition-colors",
-                              "group-hover:text-muted-foreground group-hover:border-border",
-                            )}
-                          >
-                            {item.kbd}
-                          </kbd>
-                        )}
-                      </Link>
-                    </li>
+                    <NavItemRow
+                      key={item.href}
+                      item={item}
+                      isActive={isActive}
+                    />
                   );
                 })}
               </ul>
@@ -344,5 +300,67 @@ export function Sidebar({
         </div>
       </div>
     </aside>
+  );
+}
+
+interface AnimHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+function NavItemRow({ item, isActive }: { item: NavItem; isActive: boolean }) {
+  const iconRef = useRef<AnimHandle>(null);
+
+  return (
+    <li className="relative">
+      {isActive && (
+        <span
+          aria-hidden
+          className="absolute left-0 top-1 bottom-1 w-0.75 rounded-r bg-primary shadow-[0_0_6px_rgba(34,211,238,0.5)] z-10"
+        />
+      )}
+      <Link
+        href={item.href}
+        prefetch
+        className={cn(
+          "group flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm transition-colors",
+          isActive
+            ? "bg-primary/10 text-foreground font-medium"
+            : "text-muted-foreground hover:bg-muted hover:text-foreground",
+        )}
+        onMouseEnter={() => iconRef.current?.startAnimation()}
+        onMouseLeave={() => iconRef.current?.stopAnimation()}
+      >
+        <item.icon
+          ref={iconRef}
+          size={16}
+          className={cn(
+            "shrink-0 transition-colors",
+            isActive ? "text-primary" : "text-muted-foreground group-hover:text-foreground",
+          )}
+        />
+        <span className="truncate flex-1">{item.label}</span>
+        {item.badge && (
+          <span
+            className={cn(
+              "font-mono text-[9px] px-1.5 py-0.5 rounded border leading-none tabular-nums uppercase tracking-wide",
+              TONE_CLASS[item.badge.tone],
+            )}
+          >
+            {item.badge.text}
+          </span>
+        )}
+        {item.kbd && !isActive && !item.badge && (
+          <kbd
+            className={cn(
+              "font-mono text-[9px] px-1.5 py-0.5 rounded bg-background border border-border text-muted-foreground/50 leading-none transition-colors",
+              "group-hover:text-muted-foreground group-hover:border-border",
+            )}
+          >
+            {item.kbd}
+          </kbd>
+        )}
+      </Link>
+    </li>
   );
 }

--- a/apps/web/components/dashboard/sidebar.tsx
+++ b/apps/web/components/dashboard/sidebar.tsx
@@ -7,19 +7,19 @@ import { signOut } from "next-auth/react";
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 import {
-  LayoutDashboard,
-  GitFork,
-  Key,
-  Settings,
-  LogOut,
-  CreditCard,
-  Users,
   ClipboardList,
-  MessageSquare,
   Bug,
   Loader2,
-  BarChart3,
 } from "lucide-react";
+import { LayoutGridIcon } from "@/components/ui/layout-grid";
+import { MessageSquareIcon } from "@/components/ui/message-square";
+import { GitForkIcon } from "@/components/ui/git-fork";
+import { ActivityIcon } from "@/components/ui/activity";
+import { KeyIcon } from "@/components/ui/key";
+import { UsersIcon } from "@/components/ui/users";
+import { CreditCardIcon } from "@/components/ui/credit-card";
+import { SettingsIcon } from "@/components/ui/settings";
+import { LogoutIcon } from "@/components/ui/logout";
 import { ReportButton } from "glitchgrab";
 import { cn } from "@/lib/utils";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -35,7 +35,8 @@ interface NavBadge {
 interface NavItem {
   href: string;
   label: string;
-  icon: typeof LayoutDashboard;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  icon: React.ComponentType<any>;
   ownerOnly: boolean;
   kbd?: string;
   badge?: NavBadge;
@@ -121,9 +122,9 @@ export function Sidebar({
       label: "Workspace",
       statusDot: "ok",
       items: [
-        { href: "/dashboard", label: "Overview", icon: LayoutDashboard, ownerOnly: false, kbd: "G O" },
-        { href: "/dashboard/chat", label: "Chat", icon: MessageSquare, ownerOnly: false, kbd: "G C" },
-        { href: "/dashboard/repos", label: "Repos", icon: GitFork, ownerOnly: false, kbd: "G R" },
+        { href: "/dashboard", label: "Overview", icon: LayoutGridIcon, ownerOnly: false, kbd: "G O" },
+        { href: "/dashboard/chat", label: "Chat", icon: MessageSquareIcon, ownerOnly: false, kbd: "G C" },
+        { href: "/dashboard/repos", label: "Repos", icon: GitForkIcon, ownerOnly: false, kbd: "G R" },
         {
           href: "/dashboard/reports",
           label: "Reports",
@@ -132,23 +133,23 @@ export function Sidebar({
           kbd: "G P",
           badge: reportsBadge,
         },
-        { href: "/dashboard/analytics", label: "Analytics", icon: BarChart3, ownerOnly: false, kbd: "G A" },
+        { href: "/dashboard/analytics", label: "Analytics", icon: ActivityIcon, ownerOnly: false, kbd: "G A" },
       ],
     },
     {
       label: "Config",
       items: [
-        { href: "/dashboard/tokens", label: "API Tokens", icon: Key, ownerOnly: true, kbd: "G T" },
-        { href: "/dashboard/collaborators", label: "Collaborators", icon: Users, ownerOnly: true },
+        { href: "/dashboard/tokens", label: "API Tokens", icon: KeyIcon, ownerOnly: true, kbd: "G T" },
+        { href: "/dashboard/collaborators", label: "Collaborators", icon: UsersIcon, ownerOnly: true },
         {
           href: "/dashboard/billing",
           label: "Billing",
-          icon: CreditCard,
+          icon: CreditCardIcon,
           ownerOnly: true,
           kbd: "G B",
           badge: billingBadge,
         },
-        { href: "/dashboard/settings", label: "Settings", icon: Settings, ownerOnly: true, kbd: "G S" },
+        { href: "/dashboard/settings", label: "Settings", icon: SettingsIcon, ownerOnly: true, kbd: "G S" },
       ],
     },
   ];
@@ -223,8 +224,9 @@ export function Sidebar({
                         )}
                       >
                         <item.icon
+                          size={16}
                           className={cn(
-                            "h-4 w-4 shrink-0 transition-colors",
+                            "shrink-0 transition-colors",
                             isActive
                               ? "text-primary"
                               : "text-muted-foreground group-hover:text-foreground",
@@ -337,7 +339,7 @@ export function Sidebar({
             title="Sign out"
             className="w-7 h-7 flex items-center justify-center shrink-0 rounded text-muted-foreground hover:text-red-400 hover:bg-red-400/10 transition-colors"
           >
-            <LogOut className="h-4 w-4" />
+            <LogoutIcon className="text-current" size={16} />
           </button>
         </div>
       </div>

--- a/apps/web/components/dashboard/sidebar.tsx
+++ b/apps/web/components/dashboard/sidebar.tsx
@@ -9,9 +9,9 @@ import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 import {
   ClipboardList,
-  Bug,
   Loader2,
 } from "lucide-react";
+import { BugIcon } from "@/components/ui/bug";
 import { LayoutGridIcon } from "@/components/ui/layout-grid";
 import { MessageSquareIcon } from "@/components/ui/message-square";
 import { GitForkIcon } from "@/components/ui/git-fork";
@@ -233,37 +233,7 @@ export function Sidebar({
 
         {/* Report Bug — keyboard-styled command, sticks to bottom of nav */}
         <div className="mt-auto pt-2">
-          <ReportButton>
-            {({ onClick, capturing }) => (
-              <button
-                ref={reportBtnRef}
-                type="button"
-                onClick={onClick}
-                disabled={capturing}
-                className="w-full group border border-dashed border-border hover:border-primary/50 bg-background/40 hover:bg-muted rounded-md p-2 flex items-center justify-between transition-colors focus:outline-none focus:ring-1 focus:ring-primary/50 disabled:opacity-60"
-              >
-                <span className="flex items-center gap-2 font-mono text-[11px] text-muted-foreground group-hover:text-foreground transition-colors">
-                  {capturing ? (
-                    <>
-                      <Loader2 className="h-3 w-3 animate-spin text-primary" />
-                      <span>CAPTURING…</span>
-                    </>
-                  ) : (
-                    <>
-                      <span className="text-primary group-hover:animate-pulse">{">"}</span>
-                      <Bug className="h-3 w-3 transition-transform group-hover:rotate-12 group-hover:scale-110" />
-                      <span>REPORT_BUG</span>
-                    </>
-                  )}
-                </span>
-                {!capturing && (
-                  <kbd className="font-mono text-[9px] text-muted-foreground bg-card border border-border group-hover:border-muted-foreground/40 rounded px-1.5 py-0.5 leading-none">
-                    ⌘G
-                  </kbd>
-                )}
-              </button>
-            )}
-          </ReportButton>
+          <ReportBugButton reportBtnRef={reportBtnRef} />
         </div>
       </nav>
 
@@ -320,6 +290,50 @@ export function Sidebar({
 interface AnimHandle {
   startAnimation: () => void;
   stopAnimation: () => void;
+}
+
+function ReportBugButton({ reportBtnRef }: { reportBtnRef: React.RefObject<HTMLButtonElement | null> }) {
+  const bugIconRef = useRef<AnimHandle>(null);
+
+  return (
+    <ReportButton>
+      {({ onClick, capturing }) => (
+        <button
+          ref={reportBtnRef}
+          type="button"
+          onClick={onClick}
+          disabled={capturing}
+          onMouseEnter={() => bugIconRef.current?.startAnimation()}
+          onMouseLeave={() => bugIconRef.current?.stopAnimation()}
+          className="w-full group border border-dashed border-border hover:border-primary/50 bg-background/40 hover:bg-muted rounded-md p-2 flex items-center justify-between transition-colors focus:outline-none focus:ring-1 focus:ring-primary/50 disabled:opacity-60"
+        >
+          <span className="flex items-center gap-2 font-mono text-[11px] text-muted-foreground group-hover:text-foreground transition-colors">
+            {capturing ? (
+              <>
+                <Loader2 className="h-3 w-3 animate-spin text-primary" />
+                <span>CAPTURING…</span>
+              </>
+            ) : (
+              <>
+                <span className="text-primary group-hover:animate-pulse">{">"}</span>
+                <BugIcon
+                  ref={bugIconRef}
+                  size={12}
+                  className="shrink-0 text-current"
+                />
+                <span>REPORT_BUG</span>
+              </>
+            )}
+          </span>
+          {!capturing && (
+            <kbd className="font-mono text-[9px] text-muted-foreground bg-card border border-border group-hover:border-muted-foreground/40 rounded px-1.5 py-0.5 leading-none tracking-wider">
+              CMD G
+            </kbd>
+          )}
+        </button>
+      )}
+    </ReportButton>
+  );
 }
 
 function NavItemRow({ item, isActive }: { item: NavItem; isActive: boolean }) {

--- a/apps/web/components/dashboard/sidebar.tsx
+++ b/apps/web/components/dashboard/sidebar.tsx
@@ -39,7 +39,6 @@ interface NavItem {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   icon: React.ComponentType<any>;
   ownerOnly: boolean;
-  kbd?: string;
   badge?: NavBadge;
 }
 
@@ -136,34 +135,32 @@ export function Sidebar({
       label: "Workspace",
       statusDot: "ok",
       items: [
-        { href: "/dashboard", label: "Overview", icon: LayoutGridIcon, ownerOnly: false, kbd: "G O" },
-        { href: "/dashboard/chat", label: "Chat", icon: MessageSquareIcon, ownerOnly: false, kbd: "G C" },
-        { href: "/dashboard/repos", label: "Repos", icon: GitForkIcon, ownerOnly: false, kbd: "G R" },
+        { href: "/dashboard", label: "Overview", icon: LayoutGridIcon, ownerOnly: false },
+        { href: "/dashboard/chat", label: "Chat", icon: MessageSquareIcon, ownerOnly: false },
+        { href: "/dashboard/repos", label: "Repos", icon: GitForkIcon, ownerOnly: false },
         {
           href: "/dashboard/reports",
           label: "Reports",
           icon: ClipboardList,
           ownerOnly: false,
-          kbd: "G P",
           badge: reportsBadge,
         },
-        { href: "/dashboard/analytics", label: "Analytics", icon: ActivityIcon, ownerOnly: false, kbd: "G A" },
+        { href: "/dashboard/analytics", label: "Analytics", icon: ActivityIcon, ownerOnly: false },
       ],
     },
     {
       label: "Config",
       items: [
-        { href: "/dashboard/tokens", label: "API Tokens", icon: KeyIcon, ownerOnly: true, kbd: "G T" },
+        { href: "/dashboard/tokens", label: "API Tokens", icon: KeyIcon, ownerOnly: true },
         { href: "/dashboard/collaborators", label: "Collaborators", icon: UsersIcon, ownerOnly: true },
         {
           href: "/dashboard/billing",
           label: "Billing",
           icon: CreditCardIcon,
           ownerOnly: true,
-          kbd: "G B",
           badge: billingBadge,
         },
-        { href: "/dashboard/settings", label: "Settings", icon: SettingsIcon, ownerOnly: true, kbd: "G S" },
+        { href: "/dashboard/settings", label: "Settings", icon: SettingsIcon, ownerOnly: true },
       ],
     },
   ];
@@ -377,16 +374,6 @@ function NavItemRow({ item, isActive }: { item: NavItem; isActive: boolean }) {
           >
             {item.badge.text}
           </span>
-        )}
-        {item.kbd && !isActive && !item.badge && (
-          <kbd
-            className={cn(
-              "font-mono text-[9px] px-1.5 py-0.5 rounded bg-background border border-border text-muted-foreground/50 leading-none transition-colors",
-              "group-hover:text-muted-foreground group-hover:border-border",
-            )}
-          >
-            {item.kbd}
-          </kbd>
         )}
       </Link>
     </li>

--- a/apps/web/components/dashboard/sidebar.tsx
+++ b/apps/web/components/dashboard/sidebar.tsx
@@ -18,6 +18,7 @@ import {
   MessageSquare,
   Bug,
   Loader2,
+  BarChart3,
 } from "lucide-react";
 import { ReportButton } from "glitchgrab";
 import { cn } from "@/lib/utils";
@@ -131,6 +132,7 @@ export function Sidebar({
           kbd: "G P",
           badge: reportsBadge,
         },
+        { href: "/dashboard/analytics", label: "Analytics", icon: BarChart3, ownerOnly: false, kbd: "G A" },
       ],
     },
     {

--- a/apps/web/components/ui/activity.tsx
+++ b/apps/web/components/ui/activity.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import type { Variants } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface ActivityIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface ActivityIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    pathOffset: 0,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    pathOffset: [1, 0],
+    transition: {
+      duration: 0.6,
+      ease: "linear",
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const ActivityIcon = forwardRef<ActivityIconHandle, ActivityIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <motion.path
+            animate={controls}
+            d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2"
+            initial="normal"
+            variants={VARIANTS}
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+ActivityIcon.displayName = "ActivityIcon";
+
+export { ActivityIcon };

--- a/apps/web/components/ui/bug.tsx
+++ b/apps/web/components/ui/bug.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface BugIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface BugIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const BugIcon = forwardRef<BugIconHandle, BugIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          animate={controls}
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          variants={{
+            normal: { rotate: 0, y: 0 },
+            animate: {
+              rotate: [0, -12, 12, -8, 8, -4, 4, 0],
+              y: [0, -1, 1, -1, 0],
+              transition: { duration: 0.6, ease: "easeInOut" },
+            },
+          }}
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path d="M8 2l1.88 1.88" />
+          <path d="M14.12 3.88 16 2" />
+          <path d="M9 7.13v-1a3.003 3.003 0 1 1 6 0v1" />
+          <path d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6" />
+          <path d="M12 20v-9" />
+          <path d="M6.53 9C4.6 8.8 3 7.1 3 5" />
+          <path d="M6 13H2" />
+          <path d="M3 21c0-2.1 1.7-3.9 3.8-4" />
+          <path d="M20.97 5c0 2.1-1.6 3.8-3.5 4" />
+          <path d="M22 13h-4" />
+          <path d="M17.2 17c2.1.1 3.8 1.9 3.8 4" />
+        </motion.svg>
+      </div>
+    );
+  }
+);
+
+BugIcon.displayName = "BugIcon";
+
+export { BugIcon };

--- a/apps/web/components/ui/credit-card.tsx
+++ b/apps/web/components/ui/credit-card.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import type { Variants } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface CreditCardIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface CreditCardIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const CARD_VARIANTS: Variants = {
+  normal: {
+    x: 0,
+    transition: {
+      type: "spring",
+      stiffness: 280,
+      damping: 18,
+    },
+  },
+  animate: {
+    x: [0, -4, 1.5, 0],
+    transition: {
+      duration: 0.7,
+      times: [0, 0.4, 0.75, 1],
+      ease: "easeInOut",
+    },
+  },
+};
+
+const CreditCardIcon = forwardRef<CreditCardIconHandle, CreditCardIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          className="overflow-visible"
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <motion.g
+            animate={controls}
+            initial="normal"
+            variants={CARD_VARIANTS}
+          >
+            <rect height="14" rx="2" width="20" x="2" y="5" />
+            <line x1="2" x2="22" y1="10" y2="10" />
+          </motion.g>
+        </svg>
+      </div>
+    );
+  }
+);
+
+CreditCardIcon.displayName = "CreditCardIcon";
+
+export { CreditCardIcon };

--- a/apps/web/components/ui/git-fork.tsx
+++ b/apps/web/components/ui/git-fork.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface GitForkIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface GitForkIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const DURATION = 0.3;
+
+const CALCULATE_DELAY = (i: number) => {
+  if (i === 0) return 0.1;
+
+  return i * DURATION + 0.1;
+};
+
+const GitForkIcon = forwardRef<GitForkIconHandle, GitForkIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <motion.circle
+            animate={controls}
+            cx="12"
+            cy="18"
+            r="3"
+            transition={{
+              duration: DURATION,
+              delay: CALCULATE_DELAY(0),
+              opacity: { delay: CALCULATE_DELAY(0) },
+            }}
+            variants={{
+              normal: { pathLength: 1, opacity: 1, transition: { delay: 0 } },
+              animate: {
+                pathLength: [0, 1],
+                opacity: [0, 1],
+              },
+            }}
+          />
+
+          <motion.path
+            animate={controls}
+            d="M18 9v2c0 .6-.4 1-1 1H7c-.6 0-1-.4-1-1V9"
+            transition={{
+              duration: DURATION,
+              delay: CALCULATE_DELAY(1),
+              opacity: { delay: CALCULATE_DELAY(1) },
+            }}
+            variants={{
+              normal: {
+                pathLength: 1,
+                pathOffset: 0,
+                opacity: 1,
+                transition: { delay: 0 },
+              },
+              animate: {
+                pathLength: [0, 1],
+                opacity: [0, 1],
+                pathOffset: [1, 0],
+              },
+            }}
+          />
+
+          <motion.circle
+            animate={controls}
+            cx="6"
+            cy="6"
+            r="3"
+            transition={{
+              duration: DURATION,
+              delay: CALCULATE_DELAY(2),
+              opacity: { delay: CALCULATE_DELAY(2) },
+            }}
+            variants={{
+              normal: { pathLength: 1, opacity: 1, transition: { delay: 0 } },
+              animate: {
+                pathLength: [0, 1],
+                opacity: [0, 1],
+              },
+            }}
+          />
+
+          <motion.circle
+            animate={controls}
+            cx="18"
+            cy="6"
+            r="3"
+            transition={{
+              duration: DURATION,
+              delay: CALCULATE_DELAY(2),
+              opacity: { delay: CALCULATE_DELAY(2) },
+            }}
+            variants={{
+              normal: { pathLength: 1, opacity: 1, transition: { delay: 0 } },
+              animate: {
+                pathLength: [0, 1],
+                opacity: [0, 1],
+              },
+            }}
+          />
+
+          <motion.path
+            animate={controls}
+            d="M12 12v3"
+            transition={{
+              duration: DURATION,
+              delay: CALCULATE_DELAY(1),
+              opacity: { delay: CALCULATE_DELAY(1) },
+            }}
+            variants={{
+              normal: {
+                pathLength: 1,
+                pathOffset: 0,
+                opacity: 1,
+                transition: { delay: 0 },
+              },
+              animate: {
+                pathLength: [0, 1],
+                opacity: [0, 1],
+                pathOffset: [1, 0],
+              },
+            }}
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+GitForkIcon.displayName = "GitForkIcon";
+
+export { GitForkIcon };

--- a/apps/web/components/ui/key.tsx
+++ b/apps/web/components/ui/key.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface KeyIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface KeyIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const KeyIcon = forwardRef<KeyIconHandle, KeyIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          animate={controls}
+          fill="none"
+          height={size}
+          initial="normal"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          style={{ originX: 0.3, originY: 0.7 }}
+          variants={{
+            normal: {
+              rotate: 0,
+              transition: {
+                type: "spring",
+                stiffness: 120,
+                damping: 14,
+                duration: 0.8,
+              },
+            },
+            animate: {
+              rotate: [-3, -33, -25, -28],
+              transition: {
+                duration: 0.6,
+                times: [0, 0.6, 0.8, 1],
+                ease: "easeInOut",
+              },
+            },
+          }}
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path d="m15.5 7.5 2.3 2.3a1 1 0 0 0 1.4 0l2.1-2.1a1 1 0 0 0 0-1.4L19 4" />
+          <path d="m21 2-9.6 9.6" />
+          <circle cx="7.5" cy="15.5" r="5.5" />
+        </motion.svg>
+      </div>
+    );
+  }
+);
+
+KeyIcon.displayName = "KeyIcon";
+
+export { KeyIcon };

--- a/apps/web/components/ui/layout-grid.tsx
+++ b/apps/web/components/ui/layout-grid.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import type { Variants } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface LayoutGridIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface LayoutGridIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const RECT_1_VARIANTS: Variants = {
+  normal: { translateX: 0, translateY: 0 },
+  animate: {
+    translateX: [0, 11, 11, 0],
+    translateY: [0, 0, 0, 0],
+    transition: { duration: 0.8, ease: "easeInOut", times: [0, 0.4, 0.6, 1] },
+  },
+};
+
+const RECT_2_VARIANTS: Variants = {
+  normal: { translateX: 0, translateY: 0 },
+  animate: {
+    translateX: [0, 0, 0, 0],
+    translateY: [0, 11, 11, 0],
+    transition: { duration: 0.8, ease: "easeInOut", times: [0, 0.4, 0.6, 1] },
+  },
+};
+
+const RECT_3_VARIANTS: Variants = {
+  normal: { translateX: 0, translateY: 0 },
+  animate: {
+    translateX: [0, -11, -11, 0],
+    translateY: [0, 0, 0, 0],
+    transition: { duration: 0.8, ease: "easeInOut", times: [0, 0.4, 0.6, 1] },
+  },
+};
+
+const RECT_4_VARIANTS: Variants = {
+  normal: { translateX: 0, translateY: 0 },
+  animate: {
+    translateX: [0, 0, 0, 0],
+    translateY: [0, -11, -11, 0],
+    transition: { duration: 0.8, ease: "easeInOut", times: [0, 0.4, 0.6, 1] },
+  },
+};
+
+const LayoutGridIcon = forwardRef<LayoutGridIconHandle, LayoutGridIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <motion.rect
+            animate={controls}
+            height="7"
+            initial="normal"
+            rx="1"
+            variants={RECT_1_VARIANTS}
+            width="7"
+            x="3"
+            y="3"
+          />
+          <motion.rect
+            animate={controls}
+            height="7"
+            initial="normal"
+            rx="1"
+            variants={RECT_2_VARIANTS}
+            width="7"
+            x="14"
+            y="3"
+          />
+          <motion.rect
+            animate={controls}
+            height="7"
+            initial="normal"
+            rx="1"
+            variants={RECT_3_VARIANTS}
+            width="7"
+            x="14"
+            y="14"
+          />
+          <motion.rect
+            animate={controls}
+            height="7"
+            initial="normal"
+            rx="1"
+            variants={RECT_4_VARIANTS}
+            width="7"
+            x="3"
+            y="14"
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+LayoutGridIcon.displayName = "LayoutGridIcon";
+
+export { LayoutGridIcon };

--- a/apps/web/components/ui/logout.tsx
+++ b/apps/web/components/ui/logout.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import type { Variants } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface LogoutIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface LogoutIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const PATH_VARIANTS: Variants = {
+  animate: {
+    x: 2,
+    translateX: [0, -3, 0],
+    transition: {
+      duration: 0.4,
+    },
+  },
+};
+
+const LogoutIcon = forwardRef<LogoutIconHandle, LogoutIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+          <motion.polyline
+            animate={controls}
+            points="16 17 21 12 16 7"
+            variants={PATH_VARIANTS}
+          />
+          <motion.line
+            animate={controls}
+            variants={PATH_VARIANTS}
+            x1="21"
+            x2="9"
+            y1="12"
+            y2="12"
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+LogoutIcon.displayName = "LogoutIcon";
+
+export { LogoutIcon };

--- a/apps/web/components/ui/message-square.tsx
+++ b/apps/web/components/ui/message-square.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import type { Variants } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface MessageSquareIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface MessageSquareIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const ICON_VARIANTS: Variants = {
+  normal: {
+    scale: 1,
+    rotate: 0,
+  },
+  animate: {
+    scale: 1.05,
+    rotate: [0, -7, 7, 0],
+    transition: {
+      rotate: {
+        duration: 0.5,
+        ease: "easeInOut",
+      },
+      scale: {
+        type: "spring",
+        stiffness: 400,
+        damping: 10,
+      },
+    },
+  },
+};
+
+const MessageSquareIcon = forwardRef<
+  MessageSquareIconHandle,
+  MessageSquareIconProps
+>(({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+  const controls = useAnimation();
+  const isControlledRef = useRef(false);
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true;
+
+    return {
+      startAnimation: () => controls.start("animate"),
+      stopAnimation: () => controls.start("normal"),
+    };
+  });
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (isControlledRef.current) {
+        onMouseEnter?.(e);
+      } else {
+        controls.start("animate");
+      }
+    },
+    [controls, onMouseEnter]
+  );
+
+  const handleMouseLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (isControlledRef.current) {
+        onMouseLeave?.(e);
+      } else {
+        controls.start("normal");
+      }
+    },
+    [controls, onMouseLeave]
+  );
+
+  return (
+    <div
+      className={cn(className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    >
+      <motion.svg
+        animate={controls}
+        fill="none"
+        height={size}
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
+        variants={ICON_VARIANTS}
+        viewBox="0 0 24 24"
+        width={size}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+      </motion.svg>
+    </div>
+  );
+});
+
+MessageSquareIcon.displayName = "MessageSquareIcon";
+
+export { MessageSquareIcon };

--- a/apps/web/components/ui/settings.tsx
+++ b/apps/web/components/ui/settings.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface SettingsIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface SettingsIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const SettingsIcon = forwardRef<SettingsIconHandle, SettingsIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          animate={controls}
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          transition={{ type: "spring", stiffness: 50, damping: 10 }}
+          variants={{
+            normal: {
+              rotate: 0,
+            },
+            animate: {
+              rotate: 180,
+            },
+          }}
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+          <circle cx="12" cy="12" r="3" />
+        </motion.svg>
+      </div>
+    );
+  }
+);
+
+SettingsIcon.displayName = "SettingsIcon";
+
+export { SettingsIcon };

--- a/apps/web/components/ui/trending-up.tsx
+++ b/apps/web/components/ui/trending-up.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import type { Variants } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface TrendingUpIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface TrendingUpIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const SVG_VARIANTS: Variants = {
+  animate: {
+    x: 0,
+    y: 0,
+    translateX: [0, 2, 0],
+    translateY: [0, -2, 0],
+    transition: {
+      duration: 0.5,
+    },
+  },
+};
+
+const PATH_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    pathOffset: [1, 0],
+    transition: {
+      duration: 0.4,
+      opacity: { duration: 0.1 },
+    },
+  },
+};
+
+const ARROW_VARIANTS: Variants = {
+  normal: {
+    opacity: 1,
+    pathLength: 1,
+    transition: {
+      delay: 0.3,
+      duration: 0.3,
+      opacity: { duration: 0.1, delay: 0.3 },
+    },
+  },
+  animate: {
+    opacity: [0, 1],
+    pathLength: [0, 1],
+    pathOffset: [0.5, 0],
+    transition: {
+      delay: 0.3,
+      duration: 0.3,
+      opacity: { duration: 0.1, delay: 0.3 },
+    },
+  },
+};
+
+const TrendingUpIcon = forwardRef<TrendingUpIconHandle, TrendingUpIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <motion.svg
+          animate={controls}
+          fill="none"
+          height={size}
+          initial="normal"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          variants={SVG_VARIANTS}
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <motion.polyline
+            animate={controls}
+            initial="normal"
+            points="22 7 13.5 15.5 8.5 10.5 2 17"
+            variants={PATH_VARIANTS}
+          />
+          <motion.polyline
+            animate={controls}
+            initial="normal"
+            points="16 7 22 7 22 13"
+            variants={ARROW_VARIANTS}
+          />
+        </motion.svg>
+      </div>
+    );
+  }
+);
+
+TrendingUpIcon.displayName = "TrendingUpIcon";
+
+export { TrendingUpIcon };

--- a/apps/web/components/ui/users.tsx
+++ b/apps/web/components/ui/users.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import type { Variants } from "motion/react";
+import { motion, useAnimation } from "motion/react";
+import type { HTMLAttributes } from "react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface UsersIconHandle {
+  startAnimation: () => void;
+  stopAnimation: () => void;
+}
+
+interface UsersIconProps extends HTMLAttributes<HTMLDivElement> {
+  size?: number;
+}
+
+const PATH_VARIANTS: Variants = {
+  normal: {
+    translateX: 0,
+    transition: {
+      type: "spring",
+      stiffness: 200,
+      damping: 13,
+    },
+  },
+  animate: {
+    translateX: [-6, 0],
+    transition: {
+      delay: 0.1,
+      type: "spring",
+      stiffness: 200,
+      damping: 13,
+    },
+  },
+};
+
+const UsersIcon = forwardRef<UsersIconHandle, UsersIconProps>(
+  ({ onMouseEnter, onMouseLeave, className, size = 28, ...props }, ref) => {
+    const controls = useAnimation();
+    const isControlledRef = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlledRef.current = true;
+
+      return {
+        startAnimation: () => controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleMouseEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseEnter?.(e);
+        } else {
+          controls.start("animate");
+        }
+      },
+      [controls, onMouseEnter]
+    );
+
+    const handleMouseLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (isControlledRef.current) {
+          onMouseLeave?.(e);
+        } else {
+          controls.start("normal");
+        }
+      },
+      [controls, onMouseLeave]
+    );
+
+    return (
+      <div
+        className={cn(className)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        <svg
+          fill="none"
+          height={size}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+          width={size}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+          <circle cx="9" cy="7" r="4" />
+          <motion.path
+            animate={controls}
+            d="M22 21v-2a4 4 0 0 0-3-3.87"
+            variants={PATH_VARIANTS}
+          />
+          <motion.path
+            animate={controls}
+            d="M16 3.13a4 4 0 0 1 0 7.75"
+            variants={PATH_VARIANTS}
+          />
+        </svg>
+      </div>
+    );
+  }
+);
+
+UsersIcon.displayName = "UsersIcon";
+
+export { UsersIcon };

--- a/apps/web/lib/ai.ts
+++ b/apps/web/lib/ai.ts
@@ -3,7 +3,7 @@ import { enrich } from "@/lib/claude/enricher";
 
 export type { AiAction, AiInput, ClarifyQuestion } from "@/lib/ai-types";
 
-export interface ClassifyContext {
+interface ClassifyContext {
   accessToken: string;
   owner: string;
   repo: string;

--- a/apps/web/lib/billing.ts
+++ b/apps/web/lib/billing.ts
@@ -1,7 +1,7 @@
 import { prisma } from "@/lib/db";
 import { getRazorpay } from "@/lib/razorpay";
 
-export interface UserPlan {
+interface UserPlan {
   plan: "NONE" | "PRO_PLATFORM";
   isActive: boolean;
   maxRepos: number;
@@ -82,7 +82,7 @@ export async function getUserPlan(userId: string): Promise<UserPlan> {
 
 const TRIAL_DAYS = 7;
 
-export interface TrialStatus {
+interface TrialStatus {
   inTrial: boolean;
   trialEndsAt: Date;
   daysLeft: number;

--- a/apps/web/lib/claude/enricher.ts
+++ b/apps/web/lib/claude/enricher.ts
@@ -22,13 +22,13 @@ Severity guide:
 - medium: feature partially broken, workaround exists
 - low: cosmetic, minor inconvenience`;
 
-export interface EnrichInput extends AiInput {
+interface EnrichInput extends AiInput {
   accessToken: string;
   owner: string;
   repo: string;
 }
 
-export interface EnrichResult {
+interface EnrichResult {
   action: AiAction;
   metrics: EnrichmentMetrics;
 }

--- a/apps/web/lib/collab-auth.ts
+++ b/apps/web/lib/collab-auth.ts
@@ -4,7 +4,7 @@ import { createHmac, timingSafeEqual } from "crypto";
 const COOKIE_NAME = "glitchgrab-collab-session";
 const SECRET = process.env.AUTH_SECRET || process.env.NEXTAUTH_SECRET || "collab-fallback-secret";
 
-export interface CollabSession {
+interface CollabSession {
   collaboratorId: string;
   email: string;
   ownerId: string;
@@ -22,7 +22,7 @@ export function createCollabToken(payload: CollabSession): string {
   return `${encoded}.${sig}`;
 }
 
-export function verifyCollabToken(token: string): CollabSession | null {
+function verifyCollabToken(token: string): CollabSession | null {
   try {
     const [encoded, sig] = token.split(".");
     if (!encoded || !sig) return null;

--- a/apps/web/lib/github.ts
+++ b/apps/web/lib/github.ts
@@ -1,6 +1,6 @@
 // ─── Types ──────────────────────────────────────────────
 
-export interface CreateIssueInput {
+interface CreateIssueInput {
   owner: string;
   repo: string;
   title: string;
@@ -8,7 +8,7 @@ export interface CreateIssueInput {
   labels: string[];
 }
 
-export interface CreatedIssue {
+interface CreatedIssue {
   number: number;
   url: string;
   title: string;
@@ -98,7 +98,7 @@ export async function updateIssueBody(
 
 // ─── Comment on Issue ──────────────────────────────────
 
-export async function commentOnIssue(
+async function commentOnIssue(
   accessToken: string,
   owner: string,
   repo: string,
@@ -216,7 +216,7 @@ export type WorkflowRunStatus =
   | "pending"
   | "unknown";
 
-export type WorkflowRunConclusion =
+type WorkflowRunConclusion =
   | "success"
   | "failure"
   | "cancelled"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
     "clsx": "^2.1.1",
     "glitchgrab": "workspace:*",
     "lucide-react": "^0.577.0",
+    "motion": "^12.38.0",
     "next": "^16.2.1",
     "next-auth": "^5.0.0-beta.30",
     "next-themes": "^0.4.6",

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
         "@semantic-release/git": "^10.0.1",
         "@types/node": "^25.5.0",
         "knip": "^6.0.2",
-        "pruny": "^1.43.8",
+        "pruny": "^1.45.1",
         "turbo": "^2",
       },
     },
@@ -2746,7 +2746,7 @@
 
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
-    "pruny": ["pruny@1.43.8", "", { "dependencies": { "chalk": "^5.3.0", "commander": "^12.0.0", "fast-glob": "^3.3.2", "minimatch": "^10.1.2", "prompts": "^2.4.2" }, "bin": { "pruny": "dist/index.js" } }, "sha512-3XT53gS1mRk2I3rYvZWN25rde5+Zz0Nl1D+M4uC9xHkROQaTpYaoM7DfpKRnSmqo5sNGnEQtbTHHs8FSNCSFhQ=="],
+    "pruny": ["pruny@1.45.1", "", { "dependencies": { "chalk": "^5.3.0", "commander": "^12.0.0", "fast-glob": "^3.3.2", "minimatch": "^10.1.2", "prompts": "^2.4.2" }, "bin": { "pruny": "dist/index.js" } }, "sha512-3im73ivYrm4cLdbD5FPbnI0vqGcI5ICvkq7cSSi5LxUw38UjgScZ4KwDSdBQVwvuAAOq1YCyaaWFbYDdXS9lRQ=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -65,6 +65,7 @@
         "clsx": "^2.1.1",
         "glitchgrab": "workspace:*",
         "lucide-react": "^0.577.0",
+        "motion": "^12.38.0",
         "next": "^16.2.1",
         "next-auth": "^5.0.0-beta.30",
         "next-themes": "^0.4.6",
@@ -98,7 +99,7 @@
     },
     "packages/sdk-nextjs": {
       "name": "glitchgrab",
-      "version": "1.17.1",
+      "version": "1.18.1",
       "dependencies": {
         "html2canvas-pro": "^2.0.2",
       },
@@ -1987,6 +1988,8 @@
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
+    "framer-motion": ["framer-motion@12.38.0", "", { "dependencies": { "motion-dom": "^12.38.0", "motion-utils": "^12.36.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g=="],
+
     "fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
 
     "from2": ["from2@2.3.0", "", { "dependencies": { "inherits": "^2.0.1", "readable-stream": "^2.0.0" } }, "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g=="],
@@ -2486,6 +2489,12 @@
     "mlly": ["mlly@1.8.2", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA=="],
 
     "moment": ["moment@2.30.1", "", {}, "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="],
+
+    "motion": ["motion@12.38.0", "", { "dependencies": { "framer-motion": "^12.38.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w=="],
+
+    "motion-dom": ["motion-dom@12.38.0", "", { "dependencies": { "motion-utils": "^12.36.0" } }, "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA=="],
+
+    "motion-utils": ["motion-utils@12.36.0", "", {}, "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -3939,6 +3948,8 @@
 
     "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
+    "framer-motion/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "glitchgrab/react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
     "glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
@@ -4020,6 +4031,8 @@
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "mlly/pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
+
+    "motion/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "msw/graphql": ["graphql@16.13.1", "", {}, "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ=="],
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@semantic-release/git": "^10.0.1",
     "@types/node": "^25.5.0",
     "knip": "^6.0.2",
-    "pruny": "^1.43.8",
+    "pruny": "^1.45.1",
     "turbo": "^2"
   },
   "packageManager": "bun@1.3.7",


### PR DESCRIPTION
Closes #171

## Summary
- New API endpoint `GET /api/v1/reports/analytics/issues-closed?days=7|30|90` — fetches closed GitHub issues across all connected repos and buckets them by day
- New dashboard page at `/dashboard/analytics` with a custom CSS bar chart (no new deps), 3 stat cards (total/avg/best day), hover tooltips with issue titles, and a daily breakdown table
- Sidebar: added **Analytics** nav item (keyboard shortcut G A) in the Workspace group

## Details
- Bar chart renders day-wise issue closures using flex + percentage heights — matches existing heatmap style
- Hover over any bar to see a tooltip + list of up to 5 issues closed that day (with links to GitHub)
- Date range toggle: 7D / 30D / 90D
- Falls back gracefully if GitHub token is missing or rate-limited

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Navibyte-Innovations-Pvt-Ltd/codesmith/glitchgrab/pr/174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->