### PR TITLE
fix(sdk): stop focus propagation to fix textarea clickability with radix FocusScope

### DIFF
--- a/packages/sdk-nextjs/src/report-dialog.tsx
+++ b/packages/sdk-nextjs/src/report-dialog.tsx
@@ -407,6 +407,7 @@ export function ReportDialog({
           }}
           onClick={() => { if (!previewOpen) handleClose(); }}
           onPointerDown={(e) => e.stopPropagation()}
+          onFocus={(e) => e.stopPropagation()}
         >
           <div
             ref={modalRef}


### PR DESCRIPTION
## Summary
- Radix UI's `FocusScope` (used by shadcn/ui Dialog) registers a `focusin` listener on `document` to trap focus inside the dialog. When GlitchGrab's step 2 textarea gets focused (via click or `autoFocus`), Radix detects focus leaving its container and steals it back — making the textarea unclickable/untypeable.
- Fix: added `onFocus={(e) => e.stopPropagation()}` on the GlitchGrab backdrop div. Stops `focusin` from bubbling to `document`, so Radix's FocusScope listener never fires.
- Complements the existing `onPointerDown` fix from #178 — that stopped `DismissableLayer` dismissal; this stops `FocusScope` focus theft.

## Changes
 packages/sdk-nextjs/src/report-dialog.tsx | 1 +
 1 file changed, 1 insertion(+)

## CI Pre-check
| Check | Status |
|-------|--------|
| sdk build | ✅ passed |
| sdk test (37 tests) | ✅ passed |
| lint | ✅ passed |
| knip | ✅ passed |
| pruny | ✅ passed |

## Test plan
- [ ] Open a page with a shadcn Dialog open
- [ ] Trigger GlitchGrab dialog
- [ ] Step 1: click a category (Bug/Feature/etc.)
- [ ] Step 2: click textarea and type — should work without focus being stolen
- [ ] Step 3: review and send

Closes #177

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Navibyte-Innovations-Pvt-Ltd/codesmith/glitchgrab/pr/179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->