### PR TITLE
fix(sdk): set inert on host Radix dialogs to prevent FocusScope stealing focus

### DIFF
--- a/packages/sdk-nextjs/src/report-dialog.tsx
+++ b/packages/sdk-nextjs/src/report-dialog.tsx
@@ -225,6 +225,17 @@ export function ReportDialog({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const modalRef = useRef<HTMLDivElement>(null);
 
+  // When open, set inert on any host Radix/shadcn dialogs so their FocusScope
+  // doesn't steal focus back from GlitchGrab's textarea via focusout interception.
+  useEffect(() => {
+    if (!isOpen) return;
+    const dialogs = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="dialog"][data-state="open"]')
+    );
+    dialogs.forEach((d) => d.setAttribute("inert", ""));
+    return () => dialogs.forEach((d) => d.removeAttribute("inert"));
+  }, [isOpen]);
+
   // Stepper state
   const [step, setStep] = useState(1);
   const [reportType, setReportType] = useState<ReportType>("BUG");


### PR DESCRIPTION
## Problem

When a shadcn/Radix dialog is open in the host app and the user opens the GlitchGrab report dialog, the GlitchGrab textarea is not interactive. Clicking it focuses the underlying Radix input instead.

**Root cause:** Radix `FocusScope` attaches a `focusout` listener on `document` (bubble phase). When GlitchGrab's textarea receives `.focus()`, the currently-focused Radix input fires `focusout` → Radix's handler sees focus leaving its container → immediately redirects focus back to its own input, before GlitchGrab's `focusin` even fires on the textarea.

`createPortal(content, document.body)` renders GlitchGrab outside `#__next`, but that doesn't help — Radix's FocusScope listener is on `document`, not inside React's root.

## Fix

When GlitchGrab opens, query all `[role="dialog"][data-state="open"]` elements and set the `inert` attribute on them. This disables Radix's FocusScope entirely for those elements (inert elements cannot receive focus or pointer events). On GlitchGrab close, the `inert` attributes are removed.

```tsx
useEffect(() => {
  if (!isOpen) return;
  const dialogs = Array.from(
    document.querySelectorAll<HTMLElement>('[role="dialog"][data-state="open"]')
  );
  dialogs.forEach((d) => d.setAttribute("inert", ""));
  return () => dialogs.forEach((d) => d.removeAttribute("inert"));
}, [isOpen]);
```

## Why not `stopPropagation` on `onFocus`?

PR #179 tried `onFocus={(e) => e.stopPropagation()}` — this is a no-op. Radix listens to native `focusout` (not React synthetic `focusin`), and by the time the textarea receives focus, Radix has already intercepted and redirected it. The `inert` approach prevents the problem at the source.

## Testing

Verified on PracticeStack with a shadcn upload dialog open — GlitchGrab textarea is now fully interactive.

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Navibyte-Innovations-Pvt-Ltd/codesmith/glitchgrab/pr/180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->