### PR TITLE
feat(orgs): count commits across all branches in team panel

### DIFF
--- a/apps/web/app/api/v1/orgs/[slug]/member-stats/route.ts
+++ b/apps/web/app/api/v1/orgs/[slug]/member-stats/route.ts
@@ -49,33 +49,36 @@ export async function GET(_req: Request, { params }: { params: Promise<{ slug: s
     "X-GitHub-Api-Version": "2022-11-28",
   };
 
-  // login → repoShort → count
-  const perRepo: Record<string, Record<string, number>> = {};
+  // login → repoShort → sha set (search API covers ALL branches; dedupe by SHA)
+  const perRepo: Record<string, Record<string, Set<string>>> = {};
+  const repoFilter = repos.map((r) => `repo:${r.fullName}`).join("+");
 
   await Promise.all(
-    githubMembers.flatMap((member) =>
-      repos.map(async (repo) => {
-        try {
-          const url = `https://api.github.com/repos/${repo.fullName}/commits?author=${member.login}&since=${sinceIso}&per_page=100`;
-          const res = await fetch(url, { headers: ghHeaders });
-          if (!res.ok) return;
-          const commits = (await res.json()) as unknown[];
-          if (!Array.isArray(commits) || commits.length === 0) return;
+    githubMembers.map(async (member) => {
+      try {
+        const q = `author:${member.login}+author-date:>=${sinceIso}+${repoFilter}`;
+        const url = `https://api.github.com/search/commits?q=${q}&per_page=100`;
+        const res = await fetch(url, { headers: ghHeaders });
+        if (!res.ok) return;
+        const json = (await res.json()) as { items?: Array<{ sha: string; repository: { full_name: string } }> };
+        if (!Array.isArray(json.items) || json.items.length === 0) return;
 
-          const repoShort = repo.fullName.split("/")[1] ?? repo.fullName;
-          perRepo[member.login] ??= {};
-          perRepo[member.login][repoShort] = (perRepo[member.login][repoShort] ?? 0) + commits.length;
-        } catch {
-          // fail silently
+        perRepo[member.login] ??= {};
+        for (const item of json.items) {
+          const repoShort = item.repository.full_name.split("/")[1] ?? item.repository.full_name;
+          perRepo[member.login][repoShort] ??= new Set();
+          perRepo[member.login][repoShort].add(item.sha);
         }
-      })
-    )
+      } catch {
+        // fail silently
+      }
+    })
   );
 
   const data: Record<string, MemberStat> = {};
   for (const [login, repoMap] of Object.entries(perRepo)) {
     const repos = Object.entries(repoMap)
-      .map(([name, commits]) => ({ name, commits }))
+      .map(([name, shas]) => ({ name, commits: shas.size }))
       .sort((a, b) => b.commits - a.commits);
     data[login] = { commits: repos.reduce((s, r) => s + r.commits, 0), repos };
   }

--- a/apps/web/app/api/v1/orgs/[slug]/member-stats/route.ts
+++ b/apps/web/app/api/v1/orgs/[slug]/member-stats/route.ts
@@ -5,7 +5,7 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import { getGitHubOrgMembers } from "@/lib/github";
 
-interface RepoStat { name: string; commits: number }
+interface RepoStat { name: string; commits: number; branches: string[] }
 interface MemberStat { commits: number; repos: RepoStat[] }
 
 export async function GET(_req: Request, { params }: { params: Promise<{ slug: string }> }) {
@@ -49,26 +49,49 @@ export async function GET(_req: Request, { params }: { params: Promise<{ slug: s
     "X-GitHub-Api-Version": "2022-11-28",
   };
 
-  // login → repoShort → sha set (search API covers ALL branches; dedupe by SHA)
-  const perRepo: Record<string, Record<string, Set<string>>> = {};
-  const repoFilter = repos.map((r) => `repo:${r.fullName}`).join("+");
+  // login → repoShort → { shas: SHA set, branches: branch name set }
+  const perRepo: Record<string, Record<string, { shas: Set<string>; branches: Set<string> }>> = {};
+
+  interface Branch { name: string }
+  interface Commit { sha: string; author: { login?: string } | null; commit: { author: { date: string } } }
 
   await Promise.all(
-    githubMembers.map(async (member) => {
+    repos.map(async (repo) => {
       try {
-        const q = `author:${member.login}+author-date:>=${sinceIso}+${repoFilter}`;
-        const url = `https://api.github.com/search/commits?q=${q}&per_page=100`;
-        const res = await fetch(url, { headers: ghHeaders });
-        if (!res.ok) return;
-        const json = (await res.json()) as { items?: Array<{ sha: string; repository: { full_name: string } }> };
-        if (!Array.isArray(json.items) || json.items.length === 0) return;
+        const branchRes = await fetch(`https://api.github.com/repos/${repo.fullName}/branches?per_page=100`, { headers: ghHeaders });
+        if (!branchRes.ok) return;
+        const branches = (await branchRes.json()) as Branch[];
+        if (!Array.isArray(branches)) return;
 
-        perRepo[member.login] ??= {};
-        for (const item of json.items) {
-          const repoShort = item.repository.full_name.split("/")[1] ?? item.repository.full_name;
-          perRepo[member.login][repoShort] ??= new Set();
-          perRepo[member.login][repoShort].add(item.sha);
-        }
+        const repoShort = repo.fullName.split("/")[1] ?? repo.fullName;
+
+        await Promise.all(
+          branches.flatMap((branch) =>
+            githubMembers.map(async (member) => {
+              try {
+                const url = `https://api.github.com/repos/${repo.fullName}/commits?sha=${encodeURIComponent(branch.name)}&author=${member.login}&since=${sinceIso}&per_page=100`;
+                const res = await fetch(url, { headers: ghHeaders });
+                if (!res.ok) return;
+                const commits = (await res.json()) as Commit[];
+                if (!Array.isArray(commits) || commits.length === 0) return;
+
+                perRepo[member.login] ??= {};
+                perRepo[member.login][repoShort] ??= { shas: new Set(), branches: new Set() };
+                const entry = perRepo[member.login][repoShort];
+                let added = false;
+                for (const c of commits) {
+                  if (!entry.shas.has(c.sha)) {
+                    entry.shas.add(c.sha);
+                    added = true;
+                  }
+                }
+                if (added) entry.branches.add(branch.name);
+              } catch {
+                // fail silently
+              }
+            })
+          )
+        );
       } catch {
         // fail silently
       }
@@ -78,7 +101,7 @@ export async function GET(_req: Request, { params }: { params: Promise<{ slug: s
   const data: Record<string, MemberStat> = {};
   for (const [login, repoMap] of Object.entries(perRepo)) {
     const repos = Object.entries(repoMap)
-      .map(([name, shas]) => ({ name, commits: shas.size }))
+      .map(([name, v]) => ({ name, commits: v.shas.size, branches: Array.from(v.branches).sort() }))
       .sort((a, b) => b.commits - a.commits);
     data[login] = { commits: repos.reduce((s, r) => s + r.commits, 0), repos };
   }

--- a/apps/web/app/api/v1/orgs/[slug]/today-activity/route.ts
+++ b/apps/web/app/api/v1/orgs/[slug]/today-activity/route.ts
@@ -4,8 +4,14 @@ import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 
-interface GithubCommit {
-  commit: { author: { date: string | null } | null };
+interface GithubSearchCommit {
+  sha: string;
+  repository: { full_name: string };
+}
+
+interface GithubSearchResponse {
+  total_count: number;
+  items: GithubSearchCommit[];
 }
 
 export async function GET(_req: Request, { params }: { params: Promise<{ slug: string }> }) {
@@ -61,35 +67,41 @@ export async function GET(_req: Request, { params }: { params: Promise<{ slug: s
     Accept: "application/vnd.github+json",
   };
 
-  // Count today's commits per login across all org repos
-  const counts: Record<string, { commits: number; repos: string[] }> = {};
+  // Count today's commits per login across all org repos — search API covers ALL branches
+  const counts: Record<string, { commits: number; repos: string[]; shas: Set<string> }> = {};
+  const repoFilter = repos.map((r) => `repo:${r.fullName}`).join("+");
 
   await Promise.all(
-    logins.flatMap((login) =>
-      repos.map(async (repo) => {
-        try {
-          const url = `https://api.github.com/repos/${repo.fullName}/commits?author=${login}&since=${sinceIso}&per_page=100`;
-          const res = await fetch(url, { headers });
-          if (!res.ok) return;
-          const commits = (await res.json()) as GithubCommit[];
-          if (!Array.isArray(commits) || commits.length === 0) return;
+    logins.map(async (login) => {
+      try {
+        const q = `author:${login}+author-date:>=${sinceIso}+${repoFilter}`;
+        const url = `https://api.github.com/search/commits?q=${q}&per_page=100`;
+        const res = await fetch(url, { headers });
+        if (!res.ok) return;
+        const json = (await res.json()) as GithubSearchResponse;
+        if (!Array.isArray(json.items) || json.items.length === 0) return;
 
-          const repoShort = repo.fullName.split("/")[1] ?? repo.fullName;
-          counts[login] ??= { commits: 0, repos: [] };
-          counts[login].commits += commits.length;
+        counts[login] ??= { commits: 0, repos: [], shas: new Set() };
+        for (const item of json.items) {
+          if (counts[login].shas.has(item.sha)) continue;
+          counts[login].shas.add(item.sha);
+          counts[login].commits += 1;
+          const repoShort = item.repository.full_name.split("/")[1] ?? item.repository.full_name;
           if (!counts[login].repos.includes(repoShort)) {
             counts[login].repos.push(repoShort);
           }
-        } catch {
-          // fail silently
         }
-      })
-    )
+      } catch {
+        // fail silently
+      }
+    })
   );
 
-  // Remove members with 0 commits
+  // Remove members with 0 commits, strip internal sha set
   const data = Object.fromEntries(
-    Object.entries(counts).filter(([, v]) => v.commits > 0)
+    Object.entries(counts)
+      .filter(([, v]) => v.commits > 0)
+      .map(([k, v]) => [k, { commits: v.commits, repos: v.repos }])
   );
 
   return NextResponse.json({ success: true, data });

--- a/apps/web/app/api/v1/orgs/[slug]/today-activity/route.ts
+++ b/apps/web/app/api/v1/orgs/[slug]/today-activity/route.ts
@@ -4,15 +4,8 @@ import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 
-interface GithubSearchCommit {
-  sha: string;
-  repository: { full_name: string };
-}
-
-interface GithubSearchResponse {
-  total_count: number;
-  items: GithubSearchCommit[];
-}
+interface GithubBranch { name: string }
+interface GithubCommit { sha: string }
 
 export async function GET(_req: Request, { params }: { params: Promise<{ slug: string }> }) {
   const session = await auth();
@@ -67,41 +60,48 @@ export async function GET(_req: Request, { params }: { params: Promise<{ slug: s
     Accept: "application/vnd.github+json",
   };
 
-  // Count today's commits per login across all org repos — search API covers ALL branches
-  const counts: Record<string, { commits: number; repos: string[]; shas: Set<string> }> = {};
-  const repoFilter = repos.map((r) => `repo:${r.fullName}`).join("+");
+  // login → { shas, repos } — per-branch REST covers ALL branches, dedupe by SHA
+  const counts: Record<string, { shas: Set<string>; repos: Set<string> }> = {};
 
   await Promise.all(
-    logins.map(async (login) => {
+    repos.map(async (repo) => {
       try {
-        const q = `author:${login}+author-date:>=${sinceIso}+${repoFilter}`;
-        const url = `https://api.github.com/search/commits?q=${q}&per_page=100`;
-        const res = await fetch(url, { headers });
-        if (!res.ok) return;
-        const json = (await res.json()) as GithubSearchResponse;
-        if (!Array.isArray(json.items) || json.items.length === 0) return;
+        const branchRes = await fetch(`https://api.github.com/repos/${repo.fullName}/branches?per_page=100`, { headers });
+        if (!branchRes.ok) return;
+        const branches = (await branchRes.json()) as GithubBranch[];
+        if (!Array.isArray(branches)) return;
 
-        counts[login] ??= { commits: 0, repos: [], shas: new Set() };
-        for (const item of json.items) {
-          if (counts[login].shas.has(item.sha)) continue;
-          counts[login].shas.add(item.sha);
-          counts[login].commits += 1;
-          const repoShort = item.repository.full_name.split("/")[1] ?? item.repository.full_name;
-          if (!counts[login].repos.includes(repoShort)) {
-            counts[login].repos.push(repoShort);
-          }
-        }
+        const repoShort = repo.fullName.split("/")[1] ?? repo.fullName;
+
+        await Promise.all(
+          branches.flatMap((branch) =>
+            logins.map(async (login) => {
+              try {
+                const url = `https://api.github.com/repos/${repo.fullName}/commits?sha=${encodeURIComponent(branch.name)}&author=${login}&since=${sinceIso}&per_page=100`;
+                const res = await fetch(url, { headers });
+                if (!res.ok) return;
+                const commits = (await res.json()) as GithubCommit[];
+                if (!Array.isArray(commits) || commits.length === 0) return;
+
+                counts[login] ??= { shas: new Set(), repos: new Set() };
+                for (const c of commits) counts[login].shas.add(c.sha);
+                counts[login].repos.add(repoShort);
+              } catch {
+                // fail silently
+              }
+            })
+          )
+        );
       } catch {
         // fail silently
       }
     })
   );
 
-  // Remove members with 0 commits, strip internal sha set
   const data = Object.fromEntries(
     Object.entries(counts)
-      .filter(([, v]) => v.commits > 0)
-      .map(([k, v]) => [k, { commits: v.commits, repos: v.repos }])
+      .filter(([, v]) => v.shas.size > 0)
+      .map(([k, v]) => [k, { commits: v.shas.size, repos: Array.from(v.repos) }])
   );
 
   return NextResponse.json({ success: true, data });

--- a/apps/web/app/org/[slug]/org-overview.tsx
+++ b/apps/web/app/org/[slug]/org-overview.tsx
@@ -28,6 +28,7 @@ import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@/components/ui/tooltip";
 import { ActiveWorkflowsWidget } from "@/app/dashboard/active-workflows-widget";
 import { GithubContributions } from "@/app/dashboard/github-contributions";
 import type { OrgContext } from "./lib/get-org-context";
@@ -48,7 +49,7 @@ interface MembersData {
   total: number;
 }
 
-interface RepoStat { name: string; commits: number }
+interface RepoStat { name: string; commits: number; branches?: string[] }
 interface MemberActivity {
   [githubLogin: string]: { commits: number; repos: RepoStat[] };
 }
@@ -547,9 +548,20 @@ function TeamPanel({ orgSlug, isOwner }: { orgSlug: string; isOwner: boolean }) 
                   <div className="flex-1 min-w-0">
                     <div className="text-sm font-medium text-foreground truncate">{m.name ?? m.githubLogin}</div>
                     {stats ? (
-                      <div className="text-[10px] font-mono text-primary/70 truncate">
-                        ↑ {stats.commits} commit{stats.commits !== 1 ? "s" : ""} · today · {stats.repos.slice(0, 3).map((r) => `${r.name} (${r.commits})`).join(", ")}{stats.repos.length > 3 ? ` +${stats.repos.length - 3}` : ""}
-                      </div>
+                      <TooltipProvider delay={150}>
+                        <div className="text-[10px] font-mono text-primary/70 truncate">
+                          ↑ {stats.commits} commit{stats.commits !== 1 ? "s" : ""} · today · {stats.repos.slice(0, 3).map((r) => (
+                            <Tooltip key={r.name}>
+                              <TooltipTrigger render={<span className="underline decoration-dotted underline-offset-2 cursor-help" />}>
+                                {r.name} ({r.commits})
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                {r.branches?.length ? `branches: ${r.branches.join(", ")}` : "no branch info"}
+                              </TooltipContent>
+                            </Tooltip>
+                          )).reduce((acc, el, i) => i === 0 ? [el] : [...acc, ", ", el], [] as React.ReactNode[])}{stats.repos.length > 3 ? ` +${stats.repos.length - 3}` : ""}
+                        </div>
+                      </TooltipProvider>
                     ) : memberStats !== undefined ? (
                       <div className="text-[10px] font-mono text-muted-foreground/50 truncate">
                         no commits today
@@ -636,9 +648,20 @@ function PendingMemberRow({ member, orgSlug, isOwner, stats }: { member: MergedM
         <div className="flex-1 min-w-0">
           <div className="text-sm font-medium text-muted-foreground truncate">@{member.githubLogin}</div>
           {stats ? (
-            <div className="text-[10px] font-mono text-muted-foreground/60 truncate">
-              ↑ {stats.commits} commit{stats.commits !== 1 ? "s" : ""} · today · {stats.repos.slice(0, 3).map((r) => `${r.name} (${r.commits})`).join(", ")}{stats.repos.length > 3 ? ` +${stats.repos.length - 3}` : ""}
-            </div>
+            <TooltipProvider delay={150}>
+              <div className="text-[10px] font-mono text-muted-foreground/60 truncate">
+                ↑ {stats.commits} commit{stats.commits !== 1 ? "s" : ""} · today · {stats.repos.slice(0, 3).map((r) => (
+                  <Tooltip key={r.name}>
+                    <TooltipTrigger render={<span className="underline decoration-dotted underline-offset-2 cursor-help" />}>
+                      {r.name} ({r.commits})
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {r.branches?.length ? `branches: ${r.branches.join(", ")}` : "no branch info"}
+                    </TooltipContent>
+                  </Tooltip>
+                )).reduce((acc, el, i) => i === 0 ? [el] : [...acc, ", ", el], [] as React.ReactNode[])}{stats.repos.length > 3 ? ` +${stats.repos.length - 3}` : ""}
+              </div>
+            </TooltipProvider>
           ) : null}
         </div>
         <div className="flex items-center gap-1.5 shrink-0">


### PR DESCRIPTION
## Summary
- Team panel now counts commits across all branches per repo (was: default branch only). Uses per-branch REST `/commits` calls and dedupes by SHA.
- Same fix applied to `today-activity` endpoint.
- Repo names in the team row show a tooltip listing the branches that contributed today's commits.

## Changes
 apps/web/app/api/v1/orgs/[slug]/member-stats/route.ts   | 68 +++++++++++++-------
 apps/web/app/api/v1/orgs/[slug]/today-activity/route.ts | 66 ++++++++++++------
 apps/web/app/org/[slug]/org-overview.tsx                | 37 +++++++++---
 3 files changed, 116 insertions(+), 55 deletions(-)

## CI Pre-check
| Check | Status |
|-------|--------|
| lint | passed |
| validate (eslint + tsc + knip + pruny) | passed |

## Test plan
- [ ] Open /org/<slug> — verify commit count matches actual cross-branch commits
- [ ] Hover a repo name in team panel — tooltip lists branch names
- [ ] Confirm members with no commits today are hidden

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Navibyte-Innovations-Pvt-Ltd/codesmith/glitchgrab/pr/195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->