### PR TITLE
feat(web): improve priority issues triage with filtering, copy link, and PR-linked issue exclusion

### DIFF
--- a/apps/web/app/api/v1/orgs/[slug]/issues/route.ts
+++ b/apps/web/app/api/v1/orgs/[slug]/issues/route.ts
@@ -77,6 +77,8 @@ export async function GET(_req: Request, { params }: { params: Promise<{ slug: s
     return NextResponse.json({ success: true, data: [] });
   }
 
+  const token = account.access_token;
+
   const repos = await prisma.repo.findMany({
     where: { orgId: org.id },
     select: { fullName: true },
@@ -91,12 +93,12 @@ export async function GET(_req: Request, { params }: { params: Promise<{ slug: s
               `https://api.github.com/repos/${repo.fullName}/issues?state=open&sort=created&direction=desc&per_page=10`,
               {
                 headers: {
-                  Authorization: `Bearer ${account.access_token}`,
+                  Authorization: `Bearer ${token}`,
                   Accept: "application/vnd.github+json",
                 },
               }
             ),
-            getLinkedIssueNumbers(repo.fullName, account.access_token),
+            getLinkedIssueNumbers(repo.fullName, token),
           ]);
           if (!issuesRes.ok) return [];
           const items = (await issuesRes.json()) as GithubIssue[];

--- a/apps/web/app/api/v1/orgs/[slug]/issues/route.ts
+++ b/apps/web/app/api/v1/orgs/[slug]/issues/route.ts
@@ -15,6 +15,43 @@ interface GithubIssue {
   comments: number;
 }
 
+interface GithubPR {
+  number: number;
+  body: string | null;
+  state: string;
+}
+
+// Matches: closes/close/closed/fix/fixes/fixed/resolve/resolves/resolved #N
+const CLOSING_RE = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+
+async function getLinkedIssueNumbers(repoFullName: string, token: string): Promise<Set<number>> {
+  const linked = new Set<number>();
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${repoFullName}/pulls?state=open&per_page=50`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/vnd.github+json",
+        },
+      }
+    );
+    if (!res.ok) return linked;
+    const prs = (await res.json()) as GithubPR[];
+    for (const pr of prs) {
+      if (!pr.body) continue;
+      let match: RegExpExecArray | null;
+      CLOSING_RE.lastIndex = 0;
+      while ((match = CLOSING_RE.exec(pr.body)) !== null) {
+        linked.add(Number(match[1]));
+      }
+    }
+  } catch {
+    // ignore — don't let PR fetch failure break issues
+  }
+  return linked;
+}
+
 export async function GET(_req: Request, { params }: { params: Promise<{ slug: string }> }) {
   const session = await auth();
   if (!session?.user?.id) {
@@ -49,19 +86,22 @@ export async function GET(_req: Request, { params }: { params: Promise<{ slug: s
     await Promise.all(
       repos.map(async (repo) => {
         try {
-          const res = await fetch(
-            `https://api.github.com/repos/${repo.fullName}/issues?state=open&sort=created&direction=desc&per_page=10`,
-            {
-              headers: {
-                Authorization: `Bearer ${account.access_token}`,
-                Accept: "application/vnd.github+json",
-              },
-            }
-          );
-          if (!res.ok) return [];
-          const items = (await res.json()) as GithubIssue[];
+          const [issuesRes, linkedNumbers] = await Promise.all([
+            fetch(
+              `https://api.github.com/repos/${repo.fullName}/issues?state=open&sort=created&direction=desc&per_page=10`,
+              {
+                headers: {
+                  Authorization: `Bearer ${account.access_token}`,
+                  Accept: "application/vnd.github+json",
+                },
+              }
+            ),
+            getLinkedIssueNumbers(repo.fullName, account.access_token),
+          ]);
+          if (!issuesRes.ok) return [];
+          const items = (await issuesRes.json()) as GithubIssue[];
           return items
-            .filter((i) => !i.pull_request)
+            .filter((i) => !i.pull_request && !linkedNumbers.has(i.number))
             .map((i) => ({
               number: i.number,
               title: i.title,

--- a/apps/web/app/org/[slug]/org-overview.tsx
+++ b/apps/web/app/org/[slug]/org-overview.tsx
@@ -282,6 +282,8 @@ function IssueRow({ issue, critical }: { issue: IssueItem; critical: boolean }) 
 // ─── Issues Triage ───────────────────────────────────────────────────────────
 
 function OrgIssuesTriage({ orgSlug }: { orgSlug: string }) {
+  const [selectedRepo, setSelectedRepo] = useState<string | null>(null);
+
   const { data, isLoading } = useQuery<IssueItem[]>({
     queryKey: ["org-issues", orgSlug],
     queryFn: async () => {
@@ -322,34 +324,42 @@ function OrgIssuesTriage({ orgSlug }: { orgSlug: string }) {
   }, {});
 
   const sortedRepos = Object.entries(grouped).sort(([, a], [, b]) => b.length - a.length);
-
   const topRepos = sortedRepos.slice(0, 5);
+
+  const visibleRepos = selectedRepo
+    ? topRepos.filter(([repo]) => repo === selectedRepo)
+    : topRepos;
 
   return (
     <div className="flex flex-col gap-3 max-h-80 overflow-y-auto pr-1">
-      {/* Repo chips — top 5 only */}
+      {/* Repo chips — clickable to filter */}
       <div className="flex flex-wrap gap-1.5">
         {topRepos.map(([repo, items]) => {
           const hasCritical = items.some((i) => isHighPriority(i.labels));
+          const isSelected = selectedRepo === repo;
           return (
-            <a
+            <button
               key={repo}
-              href={`https://github.com/${repo}/issues`}
-              target="_blank"
-              rel="noopener noreferrer"
+              type="button"
+              onClick={() => setSelectedRepo(isSelected ? null : repo)}
               className={cn(
                 "flex items-center gap-1 text-[10px] font-mono px-2 py-0.5 rounded border transition-colors",
-                hasCritical
-                  ? "bg-red-500/10 border-red-500/30 text-red-400 hover:border-red-500/60"
-                  : "bg-card/60 border-border text-muted-foreground hover:border-primary/50 hover:text-primary"
+                isSelected
+                  ? "bg-primary/15 border-primary/50 text-primary"
+                  : hasCritical
+                    ? "bg-red-500/10 border-red-500/30 text-red-400 hover:border-red-500/60"
+                    : "bg-card/60 border-border text-muted-foreground hover:border-primary/50 hover:text-primary"
               )}
             >
               <Folder className="h-2.5 w-2.5 shrink-0" />
               <span>{repoShortName(repo)}</span>
-              <span className={cn("font-bold px-0.5", hasCritical ? "text-red-300" : "text-foreground")}>
+              <span className={cn(
+                "font-bold px-0.5",
+                isSelected ? "text-primary" : hasCritical ? "text-red-300" : "text-foreground"
+              )}>
                 {items.length}
               </span>
-            </a>
+            </button>
           );
         })}
         {sortedRepos.length > 5 && (
@@ -359,9 +369,9 @@ function OrgIssuesTriage({ orgSlug }: { orgSlug: string }) {
         )}
       </div>
 
-      {/* Issue list — 2 per repo, compact rows */}
+      {/* Issue list — filtered by selected repo */}
       <div className="flex flex-col gap-3">
-        {topRepos.map(([repo, items]) => (
+        {visibleRepos.map(([repo, items]) => (
           <div key={repo} className="flex flex-col gap-1">
             <div className="flex items-center gap-1.5 text-[10px] font-mono text-muted-foreground/60 uppercase tracking-widest">
               <Folder className="h-2.5 w-2.5" />
@@ -369,7 +379,7 @@ function OrgIssuesTriage({ orgSlug }: { orgSlug: string }) {
               <span className="text-primary/60 ml-auto">{items.length}</span>
             </div>
             <ul className="flex flex-col gap-1">
-              {items.slice(0, 2).map((issue) => {
+              {(selectedRepo ? items : items.slice(0, 2)).map((issue) => {
                 const critical = isHighPriority(issue.labels);
                 return (
                   <li key={`${repo}-${issue.number}`}>
@@ -377,16 +387,15 @@ function OrgIssuesTriage({ orgSlug }: { orgSlug: string }) {
                   </li>
                 );
               })}
-              {items.length > 2 && (
+              {!selectedRepo && items.length > 2 && (
                 <li>
-                  <a
-                    href={`https://github.com/${repo}/issues`}
-                    target="_blank"
-                    rel="noopener noreferrer"
+                  <button
+                    type="button"
+                    onClick={() => setSelectedRepo(repo)}
                     className="text-[10px] font-mono text-muted-foreground/50 hover:text-primary transition-colors pl-1"
                   >
                     +{items.length - 2} more →
-                  </a>
+                  </button>
                 </li>
               )}
             </ul>

--- a/apps/web/app/org/[slug]/org-overview.tsx
+++ b/apps/web/app/org/[slug]/org-overview.tsx
@@ -232,7 +232,10 @@ function IssueRow({ issue, critical }: { issue: IssueItem; critical: boolean }) 
   };
 
   return (
-    <div
+    <a
+      href={issue.url}
+      target="_blank"
+      rel="noopener noreferrer"
       className={cn(
         "group flex items-center gap-2 rounded px-2 py-1.5 transition-colors border text-xs",
         critical
@@ -245,7 +248,9 @@ function IssueRow({ issue, critical }: { issue: IssueItem; critical: boolean }) 
       ) : (
         <Circle className="h-3 w-3 text-primary/50 shrink-0" />
       )}
-      <span className="flex-1 truncate text-foreground/90">{issue.title}</span>
+      <span className="flex-1 truncate text-foreground/90 group-hover:text-foreground transition-colors">
+        {issue.title}
+      </span>
       <span className="font-mono text-[10px] text-muted-foreground/50 shrink-0">
         #{issue.number} · {timeAgo(issue.createdAt)}
       </span>
@@ -258,7 +263,7 @@ function IssueRow({ issue, critical }: { issue: IssueItem; critical: boolean }) 
       <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
         <button
           type="button"
-          onClick={copyLink}
+          onClick={(e) => { e.preventDefault(); e.stopPropagation(); copyLink(); }}
           className="p-1 rounded hover:bg-muted transition-colors"
           title="Copy link"
         >
@@ -266,17 +271,11 @@ function IssueRow({ issue, critical }: { issue: IssueItem; critical: boolean }) 
             ? <Check className="h-3 w-3 text-green-400" />
             : <Copy className="h-3 w-3 text-muted-foreground" />}
         </button>
-        <a
-          href={issue.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="p-1 rounded hover:bg-muted transition-colors"
-          title="View on GitHub"
-        >
+        <span className="p-1 rounded" title="View on GitHub">
           <ExternalLink className="h-3 w-3 text-muted-foreground" />
-        </a>
+        </span>
       </div>
-    </div>
+    </a>
   );
 }
 

--- a/apps/web/app/org/[slug]/org-overview.tsx
+++ b/apps/web/app/org/[slug]/org-overview.tsx
@@ -23,6 +23,8 @@ import {
   GitPullRequest,
   RefreshCw,
   Activity,
+  Copy,
+  ExternalLink,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
@@ -218,6 +220,66 @@ function ListPanel({
   );
 }
 
+// ─── Issue Row ───────────────────────────────────────────────────────────────
+
+function IssueRow({ issue, critical }: { issue: IssueItem; critical: boolean }) {
+  const [copied, setCopied] = useState(false);
+
+  const copyLink = () => {
+    void navigator.clipboard.writeText(issue.url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div
+      className={cn(
+        "group flex items-center gap-2 rounded px-2 py-1.5 transition-colors border text-xs",
+        critical
+          ? "bg-red-500/5 border-red-500/15 hover:border-red-500/40"
+          : "bg-card/30 border-border/60 hover:border-primary/40 hover:bg-card/60"
+      )}
+    >
+      {critical ? (
+        <AlertCircle className="h-3 w-3 text-red-400 shrink-0" />
+      ) : (
+        <Circle className="h-3 w-3 text-primary/50 shrink-0" />
+      )}
+      <span className="flex-1 truncate text-foreground/90">{issue.title}</span>
+      <span className="font-mono text-[10px] text-muted-foreground/50 shrink-0">
+        #{issue.number} · {timeAgo(issue.createdAt)}
+      </span>
+      {issue.comments > 0 && (
+        <span className="font-mono text-[10px] text-muted-foreground/50 shrink-0 flex items-center gap-0.5">
+          <MessageCircle className="h-2.5 w-2.5" />
+          {issue.comments}
+        </span>
+      )}
+      <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
+        <button
+          type="button"
+          onClick={copyLink}
+          className="p-1 rounded hover:bg-muted transition-colors"
+          title="Copy link"
+        >
+          {copied
+            ? <Check className="h-3 w-3 text-green-400" />
+            : <Copy className="h-3 w-3 text-muted-foreground" />}
+        </button>
+        <a
+          href={issue.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="p-1 rounded hover:bg-muted transition-colors"
+          title="View on GitHub"
+        >
+          <ExternalLink className="h-3 w-3 text-muted-foreground" />
+        </a>
+      </div>
+    </div>
+  );
+}
+
 // ─── Issues Triage ───────────────────────────────────────────────────────────
 
 function OrgIssuesTriage({ orgSlug }: { orgSlug: string }) {
@@ -312,34 +374,7 @@ function OrgIssuesTriage({ orgSlug }: { orgSlug: string }) {
                 const critical = isHighPriority(issue.labels);
                 return (
                   <li key={`${repo}-${issue.number}`}>
-                    <a
-                      href={issue.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className={cn(
-                        "group flex items-center gap-2 rounded px-2 py-1.5 transition-colors border text-xs",
-                        critical
-                          ? "bg-red-500/5 border-red-500/15 hover:border-red-500/40"
-                          : "bg-card/30 border-border/60 hover:border-primary/40 hover:bg-card/60"
-                      )}
-                    >
-                      {critical ? (
-                        <AlertCircle className="h-3 w-3 text-red-400 shrink-0" />
-                      ) : (
-                        <Circle className="h-3 w-3 text-primary/50 shrink-0" />
-                      )}
-                      <span className="flex-1 truncate text-foreground/90 group-hover:text-foreground transition-colors">
-                        {issue.title}
-                      </span>
-                      <span className="font-mono text-[10px] text-muted-foreground/50 shrink-0">
-                        #{issue.number} · {timeAgo(issue.createdAt)}
-                      </span>
-                      {issue.comments > 0 && (
-                        <span className="font-mono text-[10px] text-muted-foreground/50 shrink-0 flex items-center gap-0.5">
-                          <MessageCircle className="h-2.5 w-2.5" />{issue.comments}
-                        </span>
-                      )}
-                    </a>
+                    <IssueRow issue={issue} critical={critical} />
                   </li>
                 );
               })}

--- a/apps/web/app/org/[slug]/org-overview.tsx
+++ b/apps/web/app/org/[slug]/org-overview.tsx
@@ -25,7 +25,11 @@ import {
   Activity,
   Copy,
   ExternalLink,
+  SlidersHorizontal,
+  Search,
+  X,
 } from "lucide-react";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import { Card, CardContent } from "@/components/ui/card";
@@ -186,7 +190,7 @@ function ListPanel({
 }: {
   icon: React.ReactNode;
   title: string;
-  meta?: string;
+  meta?: React.ReactNode;
   footer?: { href: string; label: string; external?: boolean };
   children: React.ReactNode;
 }) {
@@ -279,22 +283,112 @@ function IssueRow({ issue, critical }: { issue: IssueItem; critical: boolean }) 
   );
 }
 
-// ─── Issues Triage ───────────────────────────────────────────────────────────
+// ─── Repo Filter Popover (header button) ─────────────────────────────────────
 
-function OrgIssuesTriage({ orgSlug }: { orgSlug: string }) {
-  const [selectedRepo, setSelectedRepo] = useState<string | null>(null);
+function RepoFilterPopover({
+  allRepos,
+  selectedRepo,
+  onSelect,
+}: {
+  allRepos: [string, IssueItem[]][];
+  selectedRepo: string | null;
+  onSelect: (repo: string | null) => void;
+}) {
+  const [search, setSearch] = useState("");
 
-  const { data, isLoading } = useQuery<IssueItem[]>({
-    queryKey: ["org-issues", orgSlug],
-    queryFn: async () => {
-      const { data } = await axios.get(`/api/v1/orgs/${orgSlug}/issues`);
-      return data.data ?? [];
-    },
-    staleTime: 60_000,
-    refetchOnWindowFocus: true,
-    refetchInterval: 60_000,
-  });
+  const filteredRepos = allRepos.filter(([repo]) =>
+    repoShortName(repo).toLowerCase().includes(search.toLowerCase())
+  );
 
+  return (
+    <Popover>
+      <PopoverTrigger
+        className={cn(
+          "flex items-center gap-1 text-[10px] font-mono px-2 py-0.5 rounded border transition-colors",
+          selectedRepo
+            ? "bg-primary/15 border-primary/50 text-primary"
+            : "border-border text-muted-foreground hover:border-primary/50 hover:text-primary"
+        )}
+      >
+        <SlidersHorizontal className="h-2.5 w-2.5 shrink-0" />
+        {selectedRepo ? repoShortName(selectedRepo) : "Filter"}
+      </PopoverTrigger>
+      <PopoverContent align="end" side="bottom" className="w-56 p-2 flex flex-col gap-1.5">
+        <div className="flex items-center gap-1.5 border border-border rounded px-2 py-1 bg-background">
+          <Search className="h-3 w-3 text-muted-foreground shrink-0" />
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search repos…"
+            autoFocus
+            className="flex-1 bg-transparent text-xs font-mono text-foreground outline-none placeholder:text-muted-foreground/50"
+          />
+          {search && (
+            <button type="button" onClick={() => setSearch("")}>
+              <X className="h-3 w-3 text-muted-foreground" />
+            </button>
+          )}
+        </div>
+
+        <button
+          type="button"
+          onClick={() => onSelect(null)}
+          className={cn(
+            "flex items-center justify-between px-2 py-1 rounded text-[11px] font-mono transition-colors",
+            !selectedRepo ? "bg-primary/10 text-primary" : "text-muted-foreground hover:bg-muted hover:text-foreground"
+          )}
+        >
+          <span>All repos</span>
+          <span className="text-[10px]">{allRepos.reduce((s, [, its]) => s + its.length, 0)}</span>
+        </button>
+
+        <div className="flex flex-col gap-0.5 max-h-48 overflow-y-auto">
+          {filteredRepos.map(([repo, items]) => {
+            const isSelected = selectedRepo === repo;
+            const hasCritical = items.some((i) => isHighPriority(i.labels));
+            return (
+              <button
+                key={repo}
+                type="button"
+                onClick={() => onSelect(isSelected ? null : repo)}
+                className={cn(
+                  "flex items-center justify-between gap-2 px-2 py-1 rounded text-[11px] font-mono transition-colors",
+                  isSelected ? "bg-primary/10 text-primary" : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                )}
+              >
+                <span className="flex items-center gap-1.5 min-w-0">
+                  <Folder className="h-2.5 w-2.5 shrink-0" />
+                  <span className="truncate">{repoShortName(repo)}</span>
+                </span>
+                <span className={cn("shrink-0 text-[10px]", hasCritical && !isSelected ? "text-red-400" : "")}>
+                  {items.length}
+                </span>
+              </button>
+            );
+          })}
+          {filteredRepos.length === 0 && (
+            <p className="text-[10px] font-mono text-muted-foreground/50 px-2 py-1">No repos match</p>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+// ─── Issues Triage Body ───────────────────────────────────────────────────────
+
+function OrgIssuesTriageBody({
+  data,
+  isLoading,
+  selectedRepo,
+  onSelect,
+}: {
+  data: IssueItem[] | undefined;
+  isLoading: boolean;
+  selectedRepo: string | null;
+  onSelect: (repo: string | null) => void;
+}) {
   if (isLoading) {
     return (
       <div className="flex flex-col gap-2">
@@ -324,24 +418,24 @@ function OrgIssuesTriage({ orgSlug }: { orgSlug: string }) {
   }, {});
 
   const sortedRepos = Object.entries(grouped).sort(([, a], [, b]) => b.length - a.length);
-  const topRepos = sortedRepos.slice(0, 5);
+  const top2 = sortedRepos.slice(0, 2);
 
   const visibleRepos = selectedRepo
-    ? topRepos.filter(([repo]) => repo === selectedRepo)
-    : topRepos;
+    ? sortedRepos.filter(([repo]) => repo === selectedRepo)
+    : sortedRepos;
 
   return (
     <div className="flex flex-col gap-3 max-h-80 overflow-y-auto pr-1">
-      {/* Repo chips — clickable to filter */}
-      <div className="flex flex-wrap gap-1.5">
-        {topRepos.map(([repo, items]) => {
+      {/* Top-2 quick-filter chips */}
+      <div className="flex items-center gap-1.5 flex-wrap">
+        {top2.map(([repo, items]) => {
           const hasCritical = items.some((i) => isHighPriority(i.labels));
           const isSelected = selectedRepo === repo;
           return (
             <button
               key={repo}
               type="button"
-              onClick={() => setSelectedRepo(isSelected ? null : repo)}
+              onClick={() => onSelect(isSelected ? null : repo)}
               className={cn(
                 "flex items-center gap-1 text-[10px] font-mono px-2 py-0.5 rounded border transition-colors",
                 isSelected
@@ -353,23 +447,27 @@ function OrgIssuesTriage({ orgSlug }: { orgSlug: string }) {
             >
               <Folder className="h-2.5 w-2.5 shrink-0" />
               <span>{repoShortName(repo)}</span>
-              <span className={cn(
-                "font-bold px-0.5",
-                isSelected ? "text-primary" : hasCritical ? "text-red-300" : "text-foreground"
-              )}>
+              <span className={cn("font-bold px-0.5", isSelected ? "text-primary" : hasCritical ? "text-red-300" : "text-foreground")}>
                 {items.length}
               </span>
             </button>
           );
         })}
-        {sortedRepos.length > 5 && (
-          <span className="text-[10px] font-mono text-muted-foreground/60 self-center">
-            +{sortedRepos.length - 5} more
-          </span>
+        {/* Active filter chip if not a top-2 repo */}
+        {selectedRepo && !top2.some(([r]) => r === selectedRepo) && (
+          <button
+            type="button"
+            onClick={() => onSelect(null)}
+            className="flex items-center gap-1 text-[10px] font-mono px-2 py-0.5 rounded border bg-primary/15 border-primary/50 text-primary"
+          >
+            <Folder className="h-2.5 w-2.5 shrink-0" />
+            {repoShortName(selectedRepo)}
+            <X className="h-2.5 w-2.5" />
+          </button>
         )}
       </div>
 
-      {/* Issue list — filtered by selected repo */}
+      {/* Issue list */}
       <div className="flex flex-col gap-3">
         {visibleRepos.map(([repo, items]) => (
           <div key={repo} className="flex flex-col gap-1">
@@ -391,7 +489,7 @@ function OrgIssuesTriage({ orgSlug }: { orgSlug: string }) {
                 <li>
                   <button
                     type="button"
-                    onClick={() => setSelectedRepo(repo)}
+                    onClick={() => onSelect(repo)}
                     className="text-[10px] font-mono text-muted-foreground/50 hover:text-primary transition-colors pl-1"
                   >
                     +{items.length - 2} more →
@@ -403,6 +501,55 @@ function OrgIssuesTriage({ orgSlug }: { orgSlug: string }) {
         ))}
       </div>
     </div>
+  );
+}
+
+// ─── Issues Triage Section (holds state + query, exposes filter for header) ──
+
+function OrgIssuesTriage({ orgSlug }: { orgSlug: string }) {
+  const [selectedRepo, setSelectedRepo] = useState<string | null>(null);
+
+  const { data, isLoading } = useQuery<IssueItem[]>({
+    queryKey: ["org-issues", orgSlug],
+    queryFn: async () => {
+      const { data } = await axios.get(`/api/v1/orgs/${orgSlug}/issues`);
+      return data.data ?? [];
+    },
+    staleTime: 60_000,
+    refetchOnWindowFocus: true,
+    refetchInterval: 60_000,
+  });
+
+  const grouped = (data ?? []).reduce<Record<string, IssueItem[]>>((acc, issue) => {
+    (acc[issue.repoFullName] ??= []).push(issue);
+    return acc;
+  }, {});
+  const sortedRepos = Object.entries(grouped).sort(([, a], [, b]) => b.length - a.length);
+
+  return (
+    <ListPanel
+      icon={<AlertCircle className="h-4 w-4 text-primary" />}
+      title="Priority issues triage"
+      meta={
+        <RepoFilterPopover
+          allRepos={sortedRepos}
+          selectedRepo={selectedRepo}
+          onSelect={setSelectedRepo}
+        />
+      }
+      footer={{
+        href: `https://github.com/orgs/${orgSlug}/repositories`,
+        label: "Open on GitHub",
+        external: true,
+      }}
+    >
+      <OrgIssuesTriageBody
+        data={data}
+        isLoading={isLoading}
+        selectedRepo={selectedRepo}
+        onSelect={setSelectedRepo}
+      />
+    </ListPanel>
   );
 }
 
@@ -1079,18 +1226,7 @@ export function OrgOverview({ ctx }: { ctx: OrgContext }) {
           <TeamPanel orgSlug={ctx.orgSlug} isOwner={ctx.role === "OWNER"} />
         </ListPanel>
 
-        <ListPanel
-          icon={<AlertCircle className="h-4 w-4 text-primary" />}
-          title="Priority issues triage"
-          meta="Sort: Severity"
-          footer={{
-            href: `https://github.com/orgs/${ctx.orgSlug}/repositories`,
-            label: "Open on GitHub",
-            external: true,
-          }}
-        >
-          <OrgIssuesTriage orgSlug={ctx.orgSlug} />
-        </ListPanel>
+        <OrgIssuesTriage orgSlug={ctx.orgSlug} />
 
         <OrgIssuesClosedPreview orgSlug={ctx.orgSlug} />
       </div>


### PR DESCRIPTION
## Summary
- Add copy-link and view buttons to each issue row in Priority issues triage (appear on hover; copy shows ✓ checkmark for 2s)
- Exclude issues linked to open PRs (via closing keywords in PR bodies) from both the Open Issues stat count and triage list
- Add repo filter popover in the ListPanel header (where "Sort: Severity" was) with search input and full repo list; show top-2 repos as quick-select chips in the body; clicking any repo filters the issue list

## Changes
 apps/web/app/api/v1/orgs/[slug]/issues/route.ts |  66 ++++-
 apps/web/app/org/[slug]/org-overview.tsx        | 337 ++++++++++++++++++------
 2 files changed, 312 insertions(+), 91 deletions(-)

## CI Pre-check
| Check | Status |
|-------|--------|
| lint | ✅ passed |
| typecheck | ✅ passed |
| knip | ✅ passed |
| pruny | ✅ passed |
| build | ✅ passed |

## Test plan
- [ ] Hover an issue row — copy and external-link icons appear; copy button copies the GitHub URL
- [ ] Verify issues with open PRs referencing them (closes #N) are absent from the triage list and Open Issues count
- [ ] Click a top-2 chip — issue list filters to that repo only; click again to clear
- [ ] Open Filter popover — search narrows repo list; selecting a repo filters issues; "All repos" clears filter

Closes #201

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Navibyte-Innovations-Pvt-Ltd/codesmith/glitchgrab/pr/202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->