### PR TITLE
fix(ci): add legacy-peer-deps to unblock semantic-release

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
## Summary
- `@semantic-release/npm` runs `npm version` in `apps/web` workspace context
- `eslint-plugin-react-native-a11y@3.5.1` (in `apps/mobile`) has peer dep `eslint@^3-8`, but mobile uses `eslint@9` — npm ERESOLVE on full workspace resolution
- Root `.npmrc` with `legacy-peer-deps=true` tells npm to skip strict peer conflict check

## Changes
 .npmrc | 1 +
 1 file changed, 1 insertion(+)

## CI Pre-check
| Check | Status |
|-------|--------|
| lint | ✅ passed |
| typecheck | ⏭️ skipped (config-only change) |
| build | ⏭️ skipped (config-only change) |

## Test plan
- [ ] Verify release CI job passes after merge

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Navibyte-Innovations-Pvt-Ltd/codesmith/glitchgrab/pr/204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->