### PR TITLE
fix(org-overview): skeleton loading for commits + +N more repos hint in triage

### DIFF
--- a/apps/web/app/org/[slug]/org-overview.tsx
+++ b/apps/web/app/org/[slug]/org-overview.tsx
@@ -466,6 +466,12 @@ function OrgIssuesTriageBody({
             <X className="h-2.5 w-2.5" />
           </button>
         )}
+        {/* +N more repos hint */}
+        {sortedRepos.length > 2 && (
+          <span className="text-[10px] font-mono text-muted-foreground/50 px-1">
+            +{sortedRepos.length - 2} more
+          </span>
+        )}
       </div>
 
       {/* Issue list */}
@@ -758,7 +764,7 @@ function TeamPanel({ orgSlug, isOwner }: { orgSlug: string; isOwner: boolean }) 
                         no commits today
                       </div>
                     ) : (
-                      <div className="text-[11px] font-mono text-muted-foreground/70">@{m.githubLogin}</div>
+                      <Skeleton className="h-2.5 w-36 mt-0.5" />
                     )}
                   </div>
                   {m.role && (


### PR DESCRIPTION
## Summary
- Team panel now shows a skeleton placeholder while member commit stats are loading, instead of rendering the raw GitHub login handle (`@username`)
- Priority issues triage chips now display a `+N more` label when there are more than 2 repos with open issues, so users know additional repos exist beyond the two shown

## Changes
 apps/web/app/org/[slug]/org-overview.tsx | 8 +++++++-
 1 file changed, 7 insertions(+), 1 deletion(-)

## CI Pre-check
| Check | Status |
|-------|--------|
| lint | ✅ passed |
| typecheck | ⏭️ skipped (UI-only changes, no type surface changes) |
| build | ⏭️ skipped |

## Test plan
- [ ] Open org overview page, verify Team panel shows skeleton rows while commit data loads (not `@username` text)
- [ ] Verify that once stats load, commit info or "no commits today" renders correctly
- [ ] With 3+ repos having open issues, verify `+N more` label appears next to the triage repo chips
- [ ] With ≤2 repos, verify no `+N more` label appears

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Navibyte-Innovations-Pvt-Ltd/codesmith/glitchgrab/pr/206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->