### PR TITLE
feat(seo): add indexing status and health checks to org overview

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ Glitchgrab is an open-source SaaS tool that converts messy bug inputs (handwritt
 - **AWS S3** for screenshot storage (not Vercel Blob).
 - **Tailwind CSS v4** for styling.
 - **TanStack Query + Axios** for client-side data fetching. `useQuery` for GET, `useMutation` for POST/PATCH/DELETE. Server-side code uses raw `fetch`.
+  - **Never** use `useState` + `useEffect` to fetch data. Always `useQuery`. `useEffect` is only valid for: timers, DOM events, non-fetch side effects.
+  - After mutations: always `queryClient.invalidateQueries`. Never manually update state with `setData`.
 - **Razorpay** for subscription billing (INR ₹199/mo).
 
 ## Core concepts

--- a/apps/web/app/dashboard/seo/[id]/gsc-property-detail.tsx
+++ b/apps/web/app/dashboard/seo/[id]/gsc-property-detail.tsx
@@ -501,30 +501,26 @@ export function GscPropertyDetail({
         action={repoAction}
       />
 
-      {/* ── Stats + action cards ── */}
-      <div className="space-y-3">
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-          <StatCard label="Indexed" value={property.indexedCount} accent="green" />
-          <StatCard label="Not Indexed" value={property.notIndexedCount} accent="red" />
-          <StatCard label="Total Checked" value={total} />
-          <StatCard label="Index Rate" value={total > 0 ? `${indexedPct}%` : "—"} />
-        </div>
-
-        {total > 0 && (
-          <div className="space-y-1">
-            <div className="h-1 bg-border rounded-full overflow-hidden">
-              <div className="h-full bg-green-400 rounded-full transition-all duration-500" style={{ width: `${indexedPct}%` }} />
-            </div>
-            <p className="font-mono text-[10px] text-muted-foreground">{property.indexedCount} of {total} pages indexed</p>
-          </div>
-        )}
-
-      </div>
-
-      {/* ── Two-column body ── */}
+      {/* ── Two-column body: left = stats + indexing, right = SEO health ── */}
       <div className="grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-6 items-start min-w-0">
-        {/* LEFT — Indexing data */}
+        {/* LEFT — Stats + Indexing data */}
         <div className="space-y-4 min-w-0">
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+              <StatCard label="Indexed" value={property.indexedCount} accent="green" />
+              <StatCard label="Not Indexed" value={property.notIndexedCount} accent="red" />
+              <StatCard label="Total Checked" value={total} />
+              <StatCard label="Index Rate" value={total > 0 ? `${indexedPct}%` : "—"} />
+            </div>
+            {total > 0 && (
+              <div className="space-y-1">
+                <div className="h-1 bg-border rounded-full overflow-hidden">
+                  <div className="h-full bg-green-400 rounded-full transition-all duration-500" style={{ width: `${indexedPct}%` }} />
+                </div>
+                <p className="font-mono text-[10px] text-muted-foreground">{property.indexedCount} of {total} pages indexed</p>
+              </div>
+            )}
+          </div>
           {isSyncing && !syncResult && (
             <div className="border border-border rounded bg-card/40 overflow-hidden">
               <div className="px-4 py-3 border-b border-border/60 flex items-center gap-2">

--- a/apps/web/app/dashboard/settings/webhook-form.tsx
+++ b/apps/web/app/dashboard/settings/webhook-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect, useTransition } from "react";
+import { useState, useTransition } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import {
   Loader2,
@@ -34,8 +35,7 @@ interface WebhookInfo {
 }
 
 export function WebhookForm() {
-  const [webhooks, setWebhooks] = useState<WebhookInfo[]>([]);
-  const [loading, setLoading] = useState(true);
+  const queryClient = useQueryClient();
   const [showForm, setShowForm] = useState(false);
   const [url, setUrl] = useState("");
   const [selectedEvents, setSelectedEvents] = useState<string[]>([
@@ -46,16 +46,11 @@ export function WebhookForm() {
   const [creating, startCreate] = useTransition();
   const [deletingId, setDeletingId] = useState<string | null>(null);
 
-  useEffect(() => {
-    loadWebhooks();
-  }, []);
-
-  function loadWebhooks() {
-    listWebhooks()
-      .then(setWebhooks)
-      .catch(() => toast.error("Failed to load webhooks"))
-      .finally(() => setLoading(false));
-  }
+  const { data: webhooks = [], isLoading: loading } = useQuery<WebhookInfo[]>({
+    queryKey: ["webhooks"],
+    queryFn: () => listWebhooks(),
+    staleTime: 30_000,
+  });
 
   function toggleEvent(event: string) {
     setSelectedEvents((prev) =>
@@ -81,7 +76,7 @@ export function WebhookForm() {
         setNewSecret(result.secret);
         setUrl("");
         setSelectedEvents(["issue.created"]);
-        loadWebhooks();
+        queryClient.invalidateQueries({ queryKey: ["webhooks"] });
         toast.success("Webhook created");
       } catch (err) {
         toast.error(
@@ -95,7 +90,7 @@ export function WebhookForm() {
     setDeletingId(webhookId);
     try {
       await deleteWebhook(webhookId);
-      setWebhooks((prev) => prev.filter((w) => w.id !== webhookId));
+      queryClient.invalidateQueries({ queryKey: ["webhooks"] });
       toast.success("Webhook deleted");
     } catch {
       toast.error("Failed to delete webhook");

--- a/apps/web/app/org/[slug]/org-overview.tsx
+++ b/apps/web/app/org/[slug]/org-overview.tsx
@@ -1133,16 +1133,54 @@ function SiteFaviconSmall({ siteUrl }: { siteUrl: string }) {
   );
 }
 
+function buildHealthPrompt(
+  siteUrl: string,
+  faviconIssues: { status: string; text: string }[],
+  ogIssues: { severity: string; field: string; message: string }[],
+): string | null {
+  if (faviconIssues.length === 0 && ogIssues.length === 0) return null;
+  const parts: string[] = [`Fix the favicon and OG metadata issues for ${siteUrl}.`];
+  if (faviconIssues.length > 0) {
+    parts.push(`\nFavicon issues (${faviconIssues.length}):\n${faviconIssues.map((i) => `- [${i.status}] ${i.text}`).join("\n")}`);
+    parts.push(`\nGenerate all missing favicon files: ICO, PNG (16×16, 32×32, 96×96, 180×180), SVG, and web manifest. Add correct <link> tags in <head>.`);
+  }
+  if (ogIssues.length > 0) {
+    parts.push(`\nOG / social metadata issues (${ogIssues.length}):\n${ogIssues.map((i) => `- [${i.severity.toUpperCase()}] ${i.field}: ${i.message}`).join("\n")}`);
+    parts.push(`\nFix all OG meta tags in <head>. Ensure og:title (≤60 chars), og:description (≤160 chars), og:image (1200×630px, <300KB), og:url, twitter:card="summary_large_image".`);
+  }
+  return parts.join("\n");
+}
+
 function SeoPropertyRow({ property, orgSlug }: { property: GscSummaryItem; orgSlug: string }) {
   const [copiedIssues, setCopiedIssues] = useState(false);
-  const [healthState, setHealthState] = useState<"fetching" | "clean" | "has-issues" | "copied">("fetching");
-  const [healthPrompt, setHealthPrompt] = useState<string | null>(null);
+  const [copiedHealth, setCopiedHealth] = useState(false);
 
   const domain = getSiteDomainSmall(property.siteUrl);
   const total = property.indexedCount + property.notIndexedCount;
   const pct = total > 0 ? Math.round((property.indexedCount / total) * 100) : null;
   const notSynced = !property.lastSyncAt;
   const displayDomain = property.siteUrl.replace(/^https?:\/\//, "").replace(/\/$/, "").replace(/^sc-domain:/, "");
+
+  const { data: healthData, isFetching: isHealthFetching } = useQuery({
+    queryKey: ["seo-health", domain],
+    queryFn: async () => {
+      const [faviconRes, ogRes] = await Promise.allSettled([
+        axios.get(`/api/v1/gsc/favicon-check?domain=${encodeURIComponent(domain)}`),
+        axios.get(`/api/v1/gsc/og-check?domain=${encodeURIComponent(domain)}`),
+      ]);
+      const faviconIssues: { status: string; text: string }[] =
+        faviconRes.status === "fulfilled" && faviconRes.value.data.success
+          ? faviconRes.value.data.data.issues
+          : [];
+      const ogIssues: { severity: string; field: string; message: string }[] =
+        ogRes.status === "fulfilled" && ogRes.value.data.success
+          ? ogRes.value.data.data.issues
+          : [];
+      return { faviconIssues, ogIssues, prompt: buildHealthPrompt(property.siteUrl, faviconIssues, ogIssues) };
+    },
+    staleTime: 5 * 60_000,
+    retry: false,
+  });
 
   const { mutate: reindex, isPending: isReindexing } = useMutation({
     mutationFn: async () => {
@@ -1171,57 +1209,11 @@ Steps to diagnose and fix:
     });
   };
 
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const [faviconRes, ogRes] = await Promise.allSettled([
-          axios.get(`/api/v1/gsc/favicon-check?domain=${encodeURIComponent(domain)}`),
-          axios.get(`/api/v1/gsc/og-check?domain=${encodeURIComponent(domain)}`),
-        ]);
-        if (cancelled) return;
-
-        const faviconLines: string[] = [];
-        if (faviconRes.status === "fulfilled" && faviconRes.value.data.success) {
-          (faviconRes.value.data.data.issues as { status: string; text: string }[]).forEach((i) => {
-            faviconLines.push(`- [${i.status}] ${i.text}`);
-          });
-        }
-        const ogLines: string[] = [];
-        if (ogRes.status === "fulfilled" && ogRes.value.data.success) {
-          (ogRes.value.data.data.issues as { severity: string; field: string; message: string }[]).forEach((i) => {
-            ogLines.push(`- [${i.severity.toUpperCase()}] ${i.field}: ${i.message}`);
-          });
-        }
-
-        if (faviconLines.length === 0 && ogLines.length === 0) {
-          setHealthState("clean");
-          return;
-        }
-
-        const parts: string[] = [`Fix the favicon and OG metadata issues for ${property.siteUrl}.`];
-        if (faviconLines.length > 0) {
-          parts.push(`\nFavicon issues (${faviconLines.length}):\n${faviconLines.join("\n")}`);
-          parts.push(`\nGenerate all missing favicon files: ICO, PNG (16×16, 32×32, 96×96, 180×180), SVG, and web manifest. Add correct <link> tags in <head>.`);
-        }
-        if (ogLines.length > 0) {
-          parts.push(`\nOG / social metadata issues (${ogLines.length}):\n${ogLines.join("\n")}`);
-          parts.push(`\nFix all OG meta tags in <head>. Ensure og:title (≤60 chars), og:description (≤160 chars), og:image (1200×630px, <300KB), og:url, twitter:card="summary_large_image".`);
-        }
-        setHealthPrompt(parts.join("\n"));
-        setHealthState("has-issues");
-      } catch {
-        if (!cancelled) setHealthState("has-issues");
-      }
-    })();
-    return () => { cancelled = true; };
-  }, [domain, property.siteUrl]); // eslint-disable-line react-hooks/exhaustive-deps
-
   const copyHealthPrompt = () => {
-    if (!healthPrompt) return;
-    navigator.clipboard.writeText(healthPrompt).then(() => {
-      setHealthState("copied");
-      setTimeout(() => setHealthState("has-issues"), 2000);
+    if (!healthData?.prompt) return;
+    navigator.clipboard.writeText(healthData.prompt).then(() => {
+      setCopiedHealth(true);
+      setTimeout(() => setCopiedHealth(false), 2000);
     });
   };
 
@@ -1280,33 +1272,32 @@ Steps to diagnose and fix:
           {copiedIssues ? "Copied!" : "Page issues"}
         </button>
 
-        {healthState === "fetching" ? (
+        {isHealthFetching ? (
           <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest px-2 py-1 rounded border border-border text-muted-foreground opacity-60">
             <Loader2 className="h-3 w-3 animate-spin" />
             Checking…
           </span>
-        ) : healthState === "clean" ? (
+        ) : healthData && !healthData.prompt ? (
           <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest px-2 py-1 rounded border border-green-500/30 text-green-400 bg-green-500/10">
             <CheckCircle2 className="h-3 w-3" />
             Health OK
           </span>
-        ) : (
+        ) : healthData?.prompt ? (
           <button
             type="button"
             onClick={copyHealthPrompt}
-            disabled={healthState === "copied" || !healthPrompt}
             title="Copy favicon & OG fix prompt"
             className={cn(
               "inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest px-2 py-1 rounded border transition-colors",
-              healthState === "copied"
+              copiedHealth
                 ? "border-green-500/40 text-green-400 bg-green-500/10"
                 : "border-border text-muted-foreground hover:border-primary/40 hover:text-primary hover:bg-primary/5"
             )}
           >
-            {healthState === "copied" ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
-            {healthState === "copied" ? "Copied!" : "Favicon/OG"}
+            {copiedHealth ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+            {copiedHealth ? "Copied!" : "Favicon/OG"}
           </button>
-        )}
+        ) : null}
 
         <button
           type="button"

--- a/apps/web/app/org/[slug]/org-overview.tsx
+++ b/apps/web/app/org/[slug]/org-overview.tsx
@@ -29,6 +29,7 @@ import {
   SlidersHorizontal,
   Search,
   X,
+  Globe,
 } from "lucide-react";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
@@ -88,6 +89,14 @@ interface ClosedData {
   daily: DayBucket[];
   total: number;
   avgPerDay: number;
+}
+
+interface GscSummaryItem {
+  id: string;
+  siteUrl: string;
+  indexedCount: number;
+  notIndexedCount: number;
+  lastSyncAt: string | null;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -1099,6 +1108,146 @@ function OrgPRsOrWorkflowsPanel({ orgSlug }: { orgSlug: string }) {
   );
 }
 
+// ─── SEO Panel ────────────────────────────────────────────────────────────────
+
+function SiteFaviconSmall({ siteUrl }: { siteUrl: string }) {
+  const [failed, setFailed] = useState(false);
+  const domain = siteUrl.startsWith("sc-domain:")
+    ? siteUrl.replace("sc-domain:", "")
+    : (() => { try { return new URL(siteUrl).hostname; } catch { return siteUrl; } })();
+  if (failed) return <Globe className="h-3.5 w-3.5 text-muted-foreground shrink-0" />;
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={`/api/v1/gsc/favicon?domain=${encodeURIComponent(domain)}&size=32`}
+      alt=""
+      width={14}
+      height={14}
+      className="shrink-0 rounded-sm"
+      onError={() => setFailed(true)}
+    />
+  );
+}
+
+function OrgSeoPanel({ orgSlug }: { orgSlug: string }) {
+  const { data: properties, isLoading } = useQuery<GscSummaryItem[]>({
+    queryKey: ["gsc-properties"],
+    queryFn: async () => {
+      const { data } = await axios.get("/api/v1/gsc/properties");
+      return data.data ?? [];
+    },
+    staleTime: 60_000,
+    refetchOnWindowFocus: true,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-3">
+        <div className="flex items-center justify-between border-b border-border pb-2">
+          <h2 className="text-sm font-medium text-foreground flex items-center gap-2">
+            <Globe className="h-4 w-4 text-primary" />
+            SEO indexing
+          </h2>
+        </div>
+        <div className="flex flex-col gap-2">
+          {[1, 2].map((i) => (
+            <div key={i} className="flex items-center gap-3 rounded-md border border-border/40 px-3 py-2">
+              <Skeleton className="h-3.5 w-3.5 rounded shrink-0" />
+              <Skeleton className="h-3 flex-1" />
+              <Skeleton className="h-3 w-20 shrink-0" />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!properties || properties.length === 0) {
+    return (
+      <div className="flex flex-col gap-3">
+        <div className="flex items-center justify-between border-b border-border pb-2">
+          <h2 className="text-sm font-medium text-foreground flex items-center gap-2">
+            <Globe className="h-4 w-4 text-primary" />
+            SEO indexing
+          </h2>
+        </div>
+        <div className="flex items-center gap-3 border border-dashed border-border rounded-md px-4 py-4">
+          <Globe className="h-4 w-4 text-muted-foreground shrink-0" />
+          <p className="text-xs font-mono text-muted-foreground">No GSC properties connected.</p>
+          <Link href={`/org/${orgSlug}/seo`} className="text-xs font-mono text-primary hover:underline ml-auto shrink-0">
+            Connect →
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between border-b border-border pb-2">
+        <h2 className="text-sm font-medium text-foreground flex items-center gap-2">
+          <Globe className="h-4 w-4 text-primary" />
+          SEO indexing
+          <span className="text-[10px] font-mono text-muted-foreground">
+            {properties.length} {properties.length === 1 ? "property" : "properties"}
+          </span>
+        </h2>
+        <Link href={`/org/${orgSlug}/seo`} className="text-xs font-mono text-muted-foreground hover:text-primary transition-colors">
+          Manage →
+        </Link>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        {properties.map((p) => {
+          const total = p.indexedCount + p.notIndexedCount;
+          const pct = total > 0 ? Math.round((p.indexedCount / total) * 100) : null;
+          const notSynced = !p.lastSyncAt;
+          return (
+            <Link
+              key={p.id}
+              href={`/org/${orgSlug}/seo/${p.id}`}
+              className="group flex items-center gap-3 rounded-md border border-border/60 bg-card/30 px-3 py-2 hover:border-primary/40 hover:bg-card/60 transition-colors"
+            >
+              <SiteFaviconSmall siteUrl={p.siteUrl} />
+              <span className="flex-1 min-w-0 font-mono text-[11px] text-foreground/90 truncate group-hover:text-foreground transition-colors">
+                {p.siteUrl.replace(/^https?:\/\//, "").replace(/\/$/, "").replace(/^sc-domain:/, "")}
+              </span>
+              {notSynced ? (
+                <span className="font-mono text-[10px] text-muted-foreground shrink-0">not synced</span>
+              ) : total === 0 ? (
+                <span className="font-mono text-[10px] text-muted-foreground shrink-0">no data</span>
+              ) : (
+                <div className="flex items-center gap-2 shrink-0">
+                  <span className="font-mono text-[10px] text-green-400">{p.indexedCount} indexed</span>
+                  {p.notIndexedCount > 0 && (
+                    <span className="font-mono text-[10px] text-red-400">{p.notIndexedCount} issues</span>
+                  )}
+                  {pct !== null && (
+                    <span className={cn(
+                      "text-[10px] font-mono px-1.5 py-0.5 rounded border",
+                      pct === 100
+                        ? "text-green-400 bg-green-400/10 border-green-400/20"
+                        : pct >= 80
+                        ? "text-yellow-400 bg-yellow-400/10 border-yellow-400/20"
+                        : "text-red-400 bg-red-400/10 border-red-400/20"
+                    )}>
+                      {pct}%
+                    </span>
+                  )}
+                </div>
+              )}
+            </Link>
+          );
+        })}
+      </div>
+
+      <Link href={`/org/${orgSlug}/seo`} className="text-xs font-mono text-muted-foreground hover:text-primary transition-colors w-max mt-auto">
+        SEO details →
+      </Link>
+    </div>
+  );
+}
+
 // ─── Main Component ───────────────────────────────────────────────────────────
 
 export function OrgOverview({ ctx }: { ctx: OrgContext }) {
@@ -1152,9 +1301,23 @@ export function OrgOverview({ ctx }: { ctx: OrgContext }) {
     staleTime: 10 * 60_000,
   });
 
+  const { data: gscProperties } = useQuery<GscSummaryItem[]>({
+    queryKey: ["gsc-properties"],
+    queryFn: async () => {
+      const { data } = await axios.get("/api/v1/gsc/properties");
+      return data.data ?? [];
+    },
+    staleTime: 60_000,
+    enabled: ctx.role === "OWNER",
+  });
+
   const repoCount = ctx.repos.length;
   const memberCount = membersData?.total ?? "—";
   const openIssues = issues?.length ?? 0;
+  const totalIndexed = gscProperties?.reduce((s, p) => s + p.indexedCount, 0) ?? 0;
+  const totalNotIndexed = gscProperties?.reduce((s, p) => s + p.notIndexedCount, 0) ?? 0;
+  const totalGscPages = totalIndexed + totalNotIndexed;
+  const indexedPct = totalGscPages > 0 ? Math.round((totalIndexed / totalGscPages) * 100) : null;
 
   return (
     <div className="flex flex-col gap-6 md:gap-8">
@@ -1212,6 +1375,23 @@ export function OrgOverview({ ctx }: { ctx: OrgContext }) {
             decimal
             loading={!closedData}
           />
+          {ctx.role === "OWNER" && (
+            <StatCard
+              label="Indexed pages"
+              value={gscProperties === undefined ? 0 : totalGscPages === 0 ? "—" : totalIndexed}
+              icon={<Globe className="h-4 w-4" />}
+              pill={
+                indexedPct === null
+                  ? { text: "No data", tone: "muted" }
+                  : totalNotIndexed > 0
+                  ? { text: `${totalNotIndexed} issues`, tone: "warn" }
+                  : { text: "All indexed", tone: "primary" }
+              }
+              critical={totalNotIndexed > 0 && indexedPct !== null && indexedPct < 80}
+              href={`/org/${ctx.orgSlug}/seo`}
+              loading={ctx.role === "OWNER" && gscProperties === undefined}
+            />
+          )}
         </section>
 
         {/* Open PRs → fallback to active workflows */}
@@ -1223,7 +1403,10 @@ export function OrgOverview({ ctx }: { ctx: OrgContext }) {
       </div>
 
       {/* Three-column action lists */}
-      <div className="grid grid-cols-1 gap-4 md:gap-6 lg:grid-cols-3">
+      <div className={cn(
+        "grid grid-cols-1 gap-4 md:gap-6",
+        ctx.role === "OWNER" ? "lg:grid-cols-2 xl:grid-cols-4" : "lg:grid-cols-3"
+      )}>
         <ListPanel
           icon={<Users className="h-4 w-4 text-primary" />}
           title="Team"
@@ -1236,6 +1419,8 @@ export function OrgOverview({ ctx }: { ctx: OrgContext }) {
         <OrgIssuesTriage orgSlug={ctx.orgSlug} />
 
         <OrgIssuesClosedPreview orgSlug={ctx.orgSlug} />
+
+        {ctx.role === "OWNER" && <OrgSeoPanel orgSlug={ctx.orgSlug} />}
       </div>
 
       {/* Org-wide contributions heatmap */}

--- a/apps/web/app/org/[slug]/org-overview.tsx
+++ b/apps/web/app/org/[slug]/org-overview.tsx
@@ -30,6 +30,8 @@ import {
   Search,
   X,
   Globe,
+  ScanSearch,
+  UploadCloud,
 } from "lucide-react";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
@@ -1110,11 +1112,14 @@ function OrgPRsOrWorkflowsPanel({ orgSlug }: { orgSlug: string }) {
 
 // ─── SEO Panel ────────────────────────────────────────────────────────────────
 
+function getSiteDomainSmall(siteUrl: string): string {
+  if (siteUrl.startsWith("sc-domain:")) return siteUrl.replace("sc-domain:", "");
+  try { return new URL(siteUrl).hostname; } catch { return siteUrl; }
+}
+
 function SiteFaviconSmall({ siteUrl }: { siteUrl: string }) {
   const [failed, setFailed] = useState(false);
-  const domain = siteUrl.startsWith("sc-domain:")
-    ? siteUrl.replace("sc-domain:", "")
-    : (() => { try { return new URL(siteUrl).hostname; } catch { return siteUrl; } })();
+  const domain = getSiteDomainSmall(siteUrl);
   if (failed) return <Globe className="h-3.5 w-3.5 text-muted-foreground shrink-0" />;
   return (
     // eslint-disable-next-line @next/next/no-img-element
@@ -1126,6 +1131,189 @@ function SiteFaviconSmall({ siteUrl }: { siteUrl: string }) {
       className="shrink-0 rounded-sm"
       onError={() => setFailed(true)}
     />
+  );
+}
+
+function SeoPropertyRow({ property, orgSlug }: { property: GscSummaryItem; orgSlug: string }) {
+  const [copiedIssues, setCopiedIssues] = useState(false);
+  const [copiedHealth, setCopiedHealth] = useState(false);
+  const [healthFetching, setHealthFetching] = useState(false);
+
+  const domain = getSiteDomainSmall(property.siteUrl);
+  const total = property.indexedCount + property.notIndexedCount;
+  const pct = total > 0 ? Math.round((property.indexedCount / total) * 100) : null;
+  const notSynced = !property.lastSyncAt;
+  const displayDomain = property.siteUrl.replace(/^https?:\/\//, "").replace(/\/$/, "").replace(/^sc-domain:/, "");
+
+  const { mutate: reindex, isPending: isReindexing } = useMutation({
+    mutationFn: async () => {
+      const { data } = await axios.post("/api/v1/gsc/reindex", { propertyId: property.id });
+      if (!data.success) throw new Error(data.error ?? "Reindex failed");
+      return data.data as { submitted: number };
+    },
+    onSuccess: (result) => toast.success(`Submitted ${result.submitted} URLs for re-indexing`),
+    onError: (err) => toast.error(err instanceof Error ? err.message : "Reindex failed"),
+  });
+
+  const copyIssuesPrompt = () => {
+    const prompt = `Fix the indexing issues for ${property.siteUrl}.
+
+${property.notIndexedCount} page${property.notIndexedCount !== 1 ? "s are" : " is"} not indexed in Google Search Console.
+
+Steps to diagnose and fix:
+1. Open Google Search Console for ${property.siteUrl} → Coverage/Indexing report
+2. Review specific not-indexed URLs and their reasons (noindex tag, crawl error, redirect, canonical mismatch, etc.)
+3. Fix the root cause for each reason group
+4. Ensure affected pages have proper internal linking and are in the sitemap.xml
+5. Submit fixed pages for re-crawling via the URL Inspection tool`;
+    navigator.clipboard.writeText(prompt).then(() => {
+      setCopiedIssues(true);
+      setTimeout(() => setCopiedIssues(false), 2000);
+    });
+  };
+
+  const copyHealthPrompt = async () => {
+    setHealthFetching(true);
+    try {
+      const [faviconRes, ogRes] = await Promise.allSettled([
+        axios.get(`/api/v1/gsc/favicon-check?domain=${encodeURIComponent(domain)}`),
+        axios.get(`/api/v1/gsc/og-check?domain=${encodeURIComponent(domain)}`),
+      ]);
+
+      const faviconLines: string[] = [];
+      if (faviconRes.status === "fulfilled" && faviconRes.value.data.success) {
+        (faviconRes.value.data.data.issues as { status: string; text: string }[]).forEach((i) => {
+          faviconLines.push(`- [${i.status}] ${i.text}`);
+        });
+      }
+
+      const ogLines: string[] = [];
+      if (ogRes.status === "fulfilled" && ogRes.value.data.success) {
+        (ogRes.value.data.data.issues as { severity: string; field: string; message: string }[]).forEach((i) => {
+          ogLines.push(`- [${i.severity.toUpperCase()}] ${i.field}: ${i.message}`);
+        });
+      }
+
+      if (faviconLines.length === 0 && ogLines.length === 0) {
+        toast.success("No favicon or OG issues found!");
+        return;
+      }
+
+      const parts: string[] = [`Fix the favicon and OG metadata issues for ${property.siteUrl}.`];
+      if (faviconLines.length > 0) {
+        parts.push(`\nFavicon issues (${faviconLines.length}):\n${faviconLines.join("\n")}`);
+        parts.push(`\nGenerate all missing favicon files: ICO, PNG (16×16, 32×32, 96×96, 180×180), SVG, and web manifest. Add correct <link> tags in <head>.`);
+      }
+      if (ogLines.length > 0) {
+        parts.push(`\nOG / social metadata issues (${ogLines.length}):\n${ogLines.join("\n")}`);
+        parts.push(`\nFix all OG meta tags in <head>. Ensure og:title (≤60 chars), og:description (≤160 chars), og:image (1200×630px, <300KB), og:url, twitter:card="summary_large_image".`);
+      }
+
+      navigator.clipboard.writeText(parts.join("\n")).then(() => {
+        setCopiedHealth(true);
+        setTimeout(() => setCopiedHealth(false), 2000);
+      });
+    } catch {
+      toast.error("Failed to fetch health data");
+    } finally {
+      setHealthFetching(false);
+    }
+  };
+
+  return (
+    <div className="rounded-md border border-border/60 bg-card/30 overflow-hidden">
+      <Link
+        href={`/org/${orgSlug}/seo/${property.id}`}
+        className="group flex items-center gap-3 px-3 py-2 hover:bg-card/60 transition-colors"
+      >
+        <SiteFaviconSmall siteUrl={property.siteUrl} />
+        <span className="flex-1 min-w-0 font-mono text-[11px] text-foreground/90 truncate group-hover:text-foreground transition-colors">
+          {displayDomain}
+        </span>
+        {notSynced ? (
+          <span className="font-mono text-[10px] text-muted-foreground shrink-0">not synced</span>
+        ) : total === 0 ? (
+          <span className="font-mono text-[10px] text-muted-foreground shrink-0">no data</span>
+        ) : (
+          <div className="flex items-center gap-2 shrink-0">
+            <span className="font-mono text-[10px] text-green-400">{property.indexedCount} indexed</span>
+            {property.notIndexedCount > 0 && (
+              <span className="font-mono text-[10px] text-red-400">{property.notIndexedCount} issues</span>
+            )}
+            {pct !== null && (
+              <span className={cn(
+                "text-[10px] font-mono px-1.5 py-0.5 rounded border",
+                pct === 100
+                  ? "text-green-400 bg-green-400/10 border-green-400/20"
+                  : pct >= 80
+                  ? "text-yellow-400 bg-yellow-400/10 border-yellow-400/20"
+                  : "text-red-400 bg-red-400/10 border-red-400/20"
+              )}>
+                {pct}%
+              </span>
+            )}
+          </div>
+        )}
+      </Link>
+
+      <div className="flex items-center gap-1.5 px-3 py-1.5 border-t border-border/40 bg-background/20 flex-wrap">
+        <button
+          type="button"
+          onClick={copyIssuesPrompt}
+          disabled={property.notIndexedCount === 0}
+          title="Copy prompt to fix not-indexed pages"
+          className={cn(
+            "inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest px-2 py-1 rounded border transition-colors",
+            property.notIndexedCount === 0
+              ? "opacity-40 cursor-not-allowed border-border text-muted-foreground"
+              : copiedIssues
+              ? "border-green-500/40 text-green-400 bg-green-500/10"
+              : "border-border text-muted-foreground hover:border-primary/40 hover:text-primary hover:bg-primary/5"
+          )}
+        >
+          {copiedIssues ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+          {copiedIssues ? "Copied!" : "Page issues"}
+        </button>
+
+        <button
+          type="button"
+          onClick={copyHealthPrompt}
+          disabled={healthFetching}
+          title="Check favicon & OG health, copy fix prompt"
+          className={cn(
+            "inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest px-2 py-1 rounded border transition-colors",
+            healthFetching
+              ? "opacity-60 cursor-not-allowed border-border text-muted-foreground"
+              : copiedHealth
+              ? "border-green-500/40 text-green-400 bg-green-500/10"
+              : "border-border text-muted-foreground hover:border-primary/40 hover:text-primary hover:bg-primary/5"
+          )}
+        >
+          {healthFetching
+            ? <Loader2 className="h-3 w-3 animate-spin" />
+            : copiedHealth
+            ? <Check className="h-3 w-3" />
+            : <ScanSearch className="h-3 w-3" />}
+          {healthFetching ? "Checking…" : copiedHealth ? "Copied!" : "Favicon/OG"}
+        </button>
+
+        <button
+          type="button"
+          onClick={() => reindex()}
+          disabled={isReindexing || property.notIndexedCount === 0}
+          title="Submit not-indexed pages for re-crawling"
+          className={cn(
+            "inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest px-2 py-1 rounded border transition-colors",
+            isReindexing || property.notIndexedCount === 0
+              ? "opacity-40 cursor-not-allowed border-border text-muted-foreground"
+              : "border-amber-500/40 text-amber-400 hover:bg-amber-500/10"
+          )}
+        >
+          {isReindexing ? <Loader2 className="h-3 w-3 animate-spin" /> : <UploadCloud className="h-3 w-3" />}
+          {isReindexing ? "Submitting…" : "Reindex"}
+        </button>
+      </div>
+    </div>
   );
 }
 
@@ -1151,10 +1339,17 @@ function OrgSeoPanel({ orgSlug }: { orgSlug: string }) {
         </div>
         <div className="flex flex-col gap-2">
           {[1, 2].map((i) => (
-            <div key={i} className="flex items-center gap-3 rounded-md border border-border/40 px-3 py-2">
-              <Skeleton className="h-3.5 w-3.5 rounded shrink-0" />
-              <Skeleton className="h-3 flex-1" />
-              <Skeleton className="h-3 w-20 shrink-0" />
+            <div key={i} className="flex flex-col rounded-md border border-border/40 overflow-hidden">
+              <div className="flex items-center gap-3 px-3 py-2">
+                <Skeleton className="h-3.5 w-3.5 rounded shrink-0" />
+                <Skeleton className="h-3 flex-1" />
+                <Skeleton className="h-3 w-20 shrink-0" />
+              </div>
+              <div className="flex gap-1.5 px-3 py-1.5 border-t border-border/40">
+                <Skeleton className="h-5 w-20 rounded" />
+                <Skeleton className="h-5 w-20 rounded" />
+                <Skeleton className="h-5 w-16 rounded" />
+              </div>
             </div>
           ))}
         </div>
@@ -1198,47 +1393,9 @@ function OrgSeoPanel({ orgSlug }: { orgSlug: string }) {
       </div>
 
       <div className="flex flex-col gap-2">
-        {properties.map((p) => {
-          const total = p.indexedCount + p.notIndexedCount;
-          const pct = total > 0 ? Math.round((p.indexedCount / total) * 100) : null;
-          const notSynced = !p.lastSyncAt;
-          return (
-            <Link
-              key={p.id}
-              href={`/org/${orgSlug}/seo/${p.id}`}
-              className="group flex items-center gap-3 rounded-md border border-border/60 bg-card/30 px-3 py-2 hover:border-primary/40 hover:bg-card/60 transition-colors"
-            >
-              <SiteFaviconSmall siteUrl={p.siteUrl} />
-              <span className="flex-1 min-w-0 font-mono text-[11px] text-foreground/90 truncate group-hover:text-foreground transition-colors">
-                {p.siteUrl.replace(/^https?:\/\//, "").replace(/\/$/, "").replace(/^sc-domain:/, "")}
-              </span>
-              {notSynced ? (
-                <span className="font-mono text-[10px] text-muted-foreground shrink-0">not synced</span>
-              ) : total === 0 ? (
-                <span className="font-mono text-[10px] text-muted-foreground shrink-0">no data</span>
-              ) : (
-                <div className="flex items-center gap-2 shrink-0">
-                  <span className="font-mono text-[10px] text-green-400">{p.indexedCount} indexed</span>
-                  {p.notIndexedCount > 0 && (
-                    <span className="font-mono text-[10px] text-red-400">{p.notIndexedCount} issues</span>
-                  )}
-                  {pct !== null && (
-                    <span className={cn(
-                      "text-[10px] font-mono px-1.5 py-0.5 rounded border",
-                      pct === 100
-                        ? "text-green-400 bg-green-400/10 border-green-400/20"
-                        : pct >= 80
-                        ? "text-yellow-400 bg-yellow-400/10 border-yellow-400/20"
-                        : "text-red-400 bg-red-400/10 border-red-400/20"
-                    )}>
-                      {pct}%
-                    </span>
-                  )}
-                </div>
-              )}
-            </Link>
-          );
-        })}
+        {properties.map((p) => (
+          <SeoPropertyRow key={p.id} property={p} orgSlug={orgSlug} />
+        ))}
       </div>
 
       <Link href={`/org/${orgSlug}/seo`} className="text-xs font-mono text-muted-foreground hover:text-primary transition-colors w-max mt-auto">

--- a/apps/web/app/org/[slug]/org-overview.tsx
+++ b/apps/web/app/org/[slug]/org-overview.tsx
@@ -30,7 +30,6 @@ import {
   Search,
   X,
   Globe,
-  ScanSearch,
   UploadCloud,
 } from "lucide-react";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
@@ -1136,8 +1135,8 @@ function SiteFaviconSmall({ siteUrl }: { siteUrl: string }) {
 
 function SeoPropertyRow({ property, orgSlug }: { property: GscSummaryItem; orgSlug: string }) {
   const [copiedIssues, setCopiedIssues] = useState(false);
-  const [copiedHealth, setCopiedHealth] = useState(false);
-  const [healthFetching, setHealthFetching] = useState(false);
+  const [healthState, setHealthState] = useState<"fetching" | "clean" | "has-issues" | "copied">("fetching");
+  const [healthPrompt, setHealthPrompt] = useState<string | null>(null);
 
   const domain = getSiteDomainSmall(property.siteUrl);
   const total = property.indexedCount + property.notIndexedCount;
@@ -1172,52 +1171,58 @@ Steps to diagnose and fix:
     });
   };
 
-  const copyHealthPrompt = async () => {
-    setHealthFetching(true);
-    try {
-      const [faviconRes, ogRes] = await Promise.allSettled([
-        axios.get(`/api/v1/gsc/favicon-check?domain=${encodeURIComponent(domain)}`),
-        axios.get(`/api/v1/gsc/og-check?domain=${encodeURIComponent(domain)}`),
-      ]);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const [faviconRes, ogRes] = await Promise.allSettled([
+          axios.get(`/api/v1/gsc/favicon-check?domain=${encodeURIComponent(domain)}`),
+          axios.get(`/api/v1/gsc/og-check?domain=${encodeURIComponent(domain)}`),
+        ]);
+        if (cancelled) return;
 
-      const faviconLines: string[] = [];
-      if (faviconRes.status === "fulfilled" && faviconRes.value.data.success) {
-        (faviconRes.value.data.data.issues as { status: string; text: string }[]).forEach((i) => {
-          faviconLines.push(`- [${i.status}] ${i.text}`);
-        });
-      }
+        const faviconLines: string[] = [];
+        if (faviconRes.status === "fulfilled" && faviconRes.value.data.success) {
+          (faviconRes.value.data.data.issues as { status: string; text: string }[]).forEach((i) => {
+            faviconLines.push(`- [${i.status}] ${i.text}`);
+          });
+        }
+        const ogLines: string[] = [];
+        if (ogRes.status === "fulfilled" && ogRes.value.data.success) {
+          (ogRes.value.data.data.issues as { severity: string; field: string; message: string }[]).forEach((i) => {
+            ogLines.push(`- [${i.severity.toUpperCase()}] ${i.field}: ${i.message}`);
+          });
+        }
 
-      const ogLines: string[] = [];
-      if (ogRes.status === "fulfilled" && ogRes.value.data.success) {
-        (ogRes.value.data.data.issues as { severity: string; field: string; message: string }[]).forEach((i) => {
-          ogLines.push(`- [${i.severity.toUpperCase()}] ${i.field}: ${i.message}`);
-        });
-      }
+        if (faviconLines.length === 0 && ogLines.length === 0) {
+          setHealthState("clean");
+          return;
+        }
 
-      if (faviconLines.length === 0 && ogLines.length === 0) {
-        toast.success("No favicon or OG issues found!");
-        return;
+        const parts: string[] = [`Fix the favicon and OG metadata issues for ${property.siteUrl}.`];
+        if (faviconLines.length > 0) {
+          parts.push(`\nFavicon issues (${faviconLines.length}):\n${faviconLines.join("\n")}`);
+          parts.push(`\nGenerate all missing favicon files: ICO, PNG (16×16, 32×32, 96×96, 180×180), SVG, and web manifest. Add correct <link> tags in <head>.`);
+        }
+        if (ogLines.length > 0) {
+          parts.push(`\nOG / social metadata issues (${ogLines.length}):\n${ogLines.join("\n")}`);
+          parts.push(`\nFix all OG meta tags in <head>. Ensure og:title (≤60 chars), og:description (≤160 chars), og:image (1200×630px, <300KB), og:url, twitter:card="summary_large_image".`);
+        }
+        setHealthPrompt(parts.join("\n"));
+        setHealthState("has-issues");
+      } catch {
+        if (!cancelled) setHealthState("has-issues");
       }
+    })();
+    return () => { cancelled = true; };
+  }, [domain, property.siteUrl]); // eslint-disable-line react-hooks/exhaustive-deps
 
-      const parts: string[] = [`Fix the favicon and OG metadata issues for ${property.siteUrl}.`];
-      if (faviconLines.length > 0) {
-        parts.push(`\nFavicon issues (${faviconLines.length}):\n${faviconLines.join("\n")}`);
-        parts.push(`\nGenerate all missing favicon files: ICO, PNG (16×16, 32×32, 96×96, 180×180), SVG, and web manifest. Add correct <link> tags in <head>.`);
-      }
-      if (ogLines.length > 0) {
-        parts.push(`\nOG / social metadata issues (${ogLines.length}):\n${ogLines.join("\n")}`);
-        parts.push(`\nFix all OG meta tags in <head>. Ensure og:title (≤60 chars), og:description (≤160 chars), og:image (1200×630px, <300KB), og:url, twitter:card="summary_large_image".`);
-      }
-
-      navigator.clipboard.writeText(parts.join("\n")).then(() => {
-        setCopiedHealth(true);
-        setTimeout(() => setCopiedHealth(false), 2000);
-      });
-    } catch {
-      toast.error("Failed to fetch health data");
-    } finally {
-      setHealthFetching(false);
-    }
+  const copyHealthPrompt = () => {
+    if (!healthPrompt) return;
+    navigator.clipboard.writeText(healthPrompt).then(() => {
+      setHealthState("copied");
+      setTimeout(() => setHealthState("has-issues"), 2000);
+    });
   };
 
   return (
@@ -1275,27 +1280,33 @@ Steps to diagnose and fix:
           {copiedIssues ? "Copied!" : "Page issues"}
         </button>
 
-        <button
-          type="button"
-          onClick={copyHealthPrompt}
-          disabled={healthFetching}
-          title="Check favicon & OG health, copy fix prompt"
-          className={cn(
-            "inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest px-2 py-1 rounded border transition-colors",
-            healthFetching
-              ? "opacity-60 cursor-not-allowed border-border text-muted-foreground"
-              : copiedHealth
-              ? "border-green-500/40 text-green-400 bg-green-500/10"
-              : "border-border text-muted-foreground hover:border-primary/40 hover:text-primary hover:bg-primary/5"
-          )}
-        >
-          {healthFetching
-            ? <Loader2 className="h-3 w-3 animate-spin" />
-            : copiedHealth
-            ? <Check className="h-3 w-3" />
-            : <ScanSearch className="h-3 w-3" />}
-          {healthFetching ? "Checking…" : copiedHealth ? "Copied!" : "Favicon/OG"}
-        </button>
+        {healthState === "fetching" ? (
+          <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest px-2 py-1 rounded border border-border text-muted-foreground opacity-60">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            Checking…
+          </span>
+        ) : healthState === "clean" ? (
+          <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest px-2 py-1 rounded border border-green-500/30 text-green-400 bg-green-500/10">
+            <CheckCircle2 className="h-3 w-3" />
+            Health OK
+          </span>
+        ) : (
+          <button
+            type="button"
+            onClick={copyHealthPrompt}
+            disabled={healthState === "copied" || !healthPrompt}
+            title="Copy favicon & OG fix prompt"
+            className={cn(
+              "inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest px-2 py-1 rounded border transition-colors",
+              healthState === "copied"
+                ? "border-green-500/40 text-green-400 bg-green-500/10"
+                : "border-border text-muted-foreground hover:border-primary/40 hover:text-primary hover:bg-primary/5"
+            )}
+          >
+            {healthState === "copied" ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+            {healthState === "copied" ? "Copied!" : "Favicon/OG"}
+          </button>
+        )}
 
         <button
           type="button"


### PR DESCRIPTION
## Summary
- Adds GSC indexing stat card to org overview (OWNER-only) showing indexed pages count with link to SEO detail page
- Adds SEO panel to org overview 3-column grid showing per-property rows with page-issues prompt copy, favicon/OG health check (auto-fetched via `useQuery`), and reindex button
- Reorganizes `gsc-property-detail` layout so SEO Health column starts at the same vertical level as stat cards (stats + table in left column, health in right column from top)
- Refactors `webhook-form` to use `useQuery` + `invalidateQueries` instead of `useState+useEffect`
- Enforces `useQuery` for all data fetching in CLAUDE.md (ban `useState+useEffect` pattern)

## Changes
 CLAUDE.md                                          |   2 +
 apps/web/app/dashboard/seo/[id]/gsc-property-detail.tsx |  40 ++-
 apps/web/app/dashboard/settings/webhook-form.tsx   |  25 +-
 apps/web/app/org/[slug]/org-overview.tsx           | 346 ++++++++++++++++++++-
 4 files changed, 375 insertions(+), 38 deletions(-

## CI Pre-check
| Check | Status |
|-------|--------|
| lint | ✅ passed |
| typecheck | ✅ passed |
| build | ✅ passed |
| knip | ⚠️ pre-existing (no knip.json config) |
| pruny | ⚠️ pre-existing unused UI components |

## Test plan
- [ ] Org overview (OWNER): confirm "Indexed pages" stat card appears with correct count
- [ ] Org overview (OWNER): confirm SEO panel shows per-property rows
- [ ] SEO panel row: page-issues copy button copies prompt to clipboard
- [ ] SEO panel row: health check auto-fetches on render (no click needed); shows green badge if clean, copy button if issues
- [ ] SEO panel row: reindex button triggers reindex
- [ ] GSC property detail: SEO Health column starts at same level as stat cards
- [ ] Settings webhooks: create/delete webhook works; query invalidates correctly
- [ ] Non-OWNER member: SEO stat card and panel not shown

Closes #208

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Navibyte-Innovations-Pvt-Ltd/codesmith/glitchgrab/pr/209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->