### PR TITLE
feat(seo): embed not-indexed URLs in Page Issues copy prompt

### DIFF
--- a/apps/web/app/api/v1/gsc/properties/route.ts
+++ b/apps/web/app/api/v1/gsc/properties/route.ts
@@ -25,6 +25,7 @@ export async function GET() {
       repo: p.repo,
       indexedCount: p.indexedCount,
       notIndexedCount: p.notIndexedCount,
+      notIndexedPages: p.cachedNotIndexedPages,
       lastSyncAt: p.lastSyncAt,
       createdAt: p.createdAt,
     })),

--- a/apps/web/app/org/[slug]/org-overview.tsx
+++ b/apps/web/app/org/[slug]/org-overview.tsx
@@ -113,6 +113,7 @@ interface GscSummaryItem {
   siteUrl: string;
   indexedCount: number;
   notIndexedCount: number;
+  notIndexedPages: Array<{ url: string; reason?: string }> | null;
   lastSyncAt: string | null;
 }
 
@@ -1536,16 +1537,36 @@ function SeoPropertyRow({
   });
 
   const copyIssuesPrompt = () => {
-    const prompt = `Fix the indexing issues for ${property.siteUrl}.
+    const pages = property.notIndexedPages ?? [];
+    const grouped = new Map<string, string[]>();
+    for (const p of pages) {
+      const reason = p.reason?.trim() || "Unknown reason";
+      const list = grouped.get(reason) ?? [];
+      list.push(p.url);
+      grouped.set(reason, list);
+    }
+    const sections = Array.from(grouped.entries())
+      .sort((a, b) => b[1].length - a[1].length)
+      .map(([reason, urls]) => {
+        const list = urls.map((u) => `- ${u}`).join("\n");
+        return `## ${reason} (${urls.length})\n${list}`;
+      })
+      .join("\n\n");
 
-${property.notIndexedCount} page${property.notIndexedCount !== 1 ? "s are" : " is"} not indexed in Google Search Console.
+    const prompt = `Fix Google Search Console indexing issues for ${property.siteUrl}.
 
-Steps to diagnose and fix:
-1. Open Google Search Console for ${property.siteUrl} → Coverage/Indexing report
-2. Review specific not-indexed URLs and their reasons (noindex tag, crawl error, redirect, canonical mismatch, etc.)
-3. Fix the root cause for each reason group
-4. Ensure affected pages have proper internal linking and are in the sitemap.xml
-5. Submit fixed pages for re-crawling via the URL Inspection tool`;
+${property.notIndexedCount} page${property.notIndexedCount !== 1 ? "s are" : " is"} not indexed. Fix the root cause in the codebase for each URL below.
+
+${sections || "(No cached URLs — run Sync now first.)"}
+
+For every URL above:
+1. Open the page locally and confirm it renders with status 200.
+2. Inspect <head>: no noindex meta, correct canonical, valid hreflang.
+3. Confirm the URL is in sitemap.xml and reachable via internal links.
+4. Check robots.txt does not disallow it.
+5. For redirects/canonical mismatches, fix so the canonical URL is the indexed one.
+6. After fixing, request re-indexing in GSC URL Inspection.`;
+
     navigator.clipboard.writeText(prompt).then(() => {
       setCopiedIssues(true);
       setTimeout(() => setCopiedIssues(false), 2000);


### PR DESCRIPTION
## Summary
- Page Issues copy on org SEO panel now embeds actual not-indexed URLs grouped by GSC reason — no more "go to GSC and do X" dictation.
- `/api/v1/gsc/properties` GET exposes `notIndexedPages` from the existing `cachedNotIndexedPages` column so the client can build the prompt without an extra round-trip.
- Output is directly pasteable into Claude Code; favicon/OG copy was already data-driven and untouched.

## Changes
```
 apps/web/app/api/v1/gsc/properties/route.ts |  1 +
 apps/web/app/org/[slug]/org-overview.tsx    | 39 ++++++++++++++++++++++-------
 2 files changed, 31 insertions(+), 9 deletions(-)
```

## CI Pre-check
| Check | Status |
|-------|--------|
| validate (lint + tsc) | ✅ passed |
| knip | ✅ passed |
| pruny | ✅ passed |
| sdk test | ✅ passed (37/37) |
| web build | ⏭️ skipped locally (env-dependent; CI runs it) |

## Test plan
- [ ] Open org SEO panel; click "Page issues" on a property with cached non-indexed URLs — clipboard should contain actual URLs grouped by GSC reason
- [ ] Property with `notIndexedCount > 0` but no cached pages (pre-sync) — prompt falls back to "(No cached URLs — run Sync now first.)"
- [ ] Property with `notIndexedCount === 0` — button is disabled (unchanged behavior)
- [ ] Favicon/OG "Health" button still copies the existing health prompt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Navibyte-Innovations-Pvt-Ltd/codesmith/glitchgrab/pr/212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->